### PR TITLE
Add logo selector to fix svgs

### DIFF
--- a/frontend/scss/components/textbook__page.scss
+++ b/frontend/scss/components/textbook__page.scss
@@ -69,7 +69,8 @@
   max-width: $page-max-width;
 }
 
-.c-textbook__content .p-Widget {
+.c-textbook__content .p-Widget,
+.app-logo.menu__logo {
   circle,
   g,
   image,


### PR DESCRIPTION
Adding the Logo selector to fix the svg


**from this**
<img width="172" alt="Screen Shot 2021-06-23 at 8 45 37 AM" src="https://user-images.githubusercontent.com/6276074/123127835-e06c8500-d407-11eb-85d7-5228652e355b.png">




**to this**

<img width="185" alt="Screen Shot 2021-06-23 at 8 45 50 AM" src="https://user-images.githubusercontent.com/6276074/123127867-e6626600-d407-11eb-9da3-b8fbcba5190c.png">
