### PR TITLE
disable line wrapping

### DIFF
--- a/server/includes/thebe-config.html
+++ b/server/includes/thebe-config.html
@@ -5,7 +5,7 @@
     ref: "platypus-binder",
   },
   codeMirrorconfig: {
-    lineWrapping: true
+    lineWrapping: false
   },
   codeMirrorConfig: {
     theme: "abcdef",


### PR DESCRIPTION
this PR disabled the CodeMirror `lineWrapping` setting for the code cells. this will result in long lines scrolling instead of wrapping.

**before**:

<img width="623" alt="image" src="https://user-images.githubusercontent.com/13156555/123692479-db06a480-d824-11eb-9f1b-750ffc3b0726.png">

**after**:

<img width="620" alt="image" src="https://user-images.githubusercontent.com/13156555/123692554-f07bce80-d824-11eb-98a1-3000cf4155ae.png">

---

Related Qiskit/platypus#543