### PR TITLE
add banner

### DIFF
--- a/frontend/scss/components/textbook__page.scss
+++ b/frontend/scss/components/textbook__page.scss
@@ -60,7 +60,7 @@
 
 .c-textbook__content {
   clear: both;
-  padding-top: $qiskit-navbar-height;
+  padding-top: calc(#{$qiskit-navbar-height} + #{$textbook-page-banner-height});
   width: 95%;
 }
 
@@ -138,14 +138,14 @@ img.textbook_logo {
 
 // hidden panel styles
 .qv-layout__panel--hidden.js-show-sidebar .c-textbook__page{
-  transform: translate($spacing-10, 0);
+  transform: translate($spacing-09, 0);
   width: calc(100% - #{$spacing-07});
-  padding: 0 32px 40px 0;
+  padding: 0 $spacing-07 $spacing-08 $spacing-04;
 
   @include mq($until: medium) {
-    transform: translate($spacing-05, 0);
+    transform: translate(0, 0);
     width: 100%;
-    padding: $spacing-05 $spacing-07 $spacing-09 0;
+    padding: $spacing-05 $spacing-07 $spacing-09 $spacing-unit-small;
   }
 }
 
@@ -215,4 +215,34 @@ div.preface-checker-pattern {
   margin: initial;
   margin-bottom: 25px;
   float: initial;
+}
+
+// banner
+.page__banner {
+  background-color: $block-background-color;
+  color: $text-color-white;
+  height: $textbook-page-banner-height;
+  font-size: 14px;
+  letter-spacing: 0.16px;
+  line-height: 20px;
+  padding: $spacing-03 $spacing-07 $spacing-03 $spacing-05;
+  position: absolute;
+  left: 0;
+  right: 0;
+
+  a {
+    &:visited,
+    &:active,
+    &:hover {
+      color: $text-color-white;
+    }
+
+    color: $text-color-white;
+    text-decoration: underline;
+  }
+
+  @include mq($until: medium) {
+    top: 40px; 
+    height: initial;
+  }
 }

--- a/frontend/scss/variables/settings.scss
+++ b/frontend/scss/variables/settings.scss
@@ -5,6 +5,7 @@ $content-max-width: 46rem;
 $textbook-page-width: 100%;
 
 $qiskit-navbar-height: 60px;
+$textbook-page-banner-height: 40px;
 
 $left-sidebar-width: 256px;
 $right-sidebar-width: 30rem;

--- a/frontend/scss/vendor/mathigon.scss
+++ b/frontend/scss/vendor/mathigon.scss
@@ -1,6 +1,7 @@
 /* Override of Mathigon styles */
 @import '../../../node_modules/carbon-components/scss/globals/scss/typography';
 @import '../variables/colors.scss';
+@import '../variables/mq.scss';
 @import '../variables/fonts.scss';
 
 x-step {
@@ -33,7 +34,7 @@ pre {
   border-right: 1px solid $border-color-secondary;
   color: $text-color-light;
   padding: $spacing-03 $spacing-07 $spacing-03 $spacing-05;
-  top: 0px;
+  top: 52px;
   left: 0px;
 
   .complete {
@@ -59,6 +60,10 @@ pre {
     .complete {
       display: none;
     }
+  }
+
+  @include mq($until: medium) {
+    top: 90px;
   }
 }
 

--- a/server/templates/banner.pug
+++ b/server/templates/banner.pug
@@ -1,0 +1,7 @@
+div.page__banner
+  | Miss the old version of the textbook? Access it 
+  a(
+    href="https://qiskit.org/textbook"
+    onclick="textbook.trackClickEvent('old verion > qiskit.org/textbook')"
+    target="_blank"
+  ) here

--- a/server/templates/textbook.pug
+++ b/server/templates/textbook.pug
@@ -18,6 +18,7 @@ html(lang=lang dir=dir)
         include sidebar
 
         article(class="c-textbook__page")
+          include banner
           div.c-textbook__content#textbook_content
             div.jupyter-page
 


### PR DESCRIPTION
this PR 

- adds a banner to the top of the content pages to allow users to return the original textbook
- fixes issue with margin/spacing when the left sidebar is collapsed

**before**

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/13156555/124239273-86468080-dae7-11eb-97da-5e87484a5ce1.png">

![image](https://user-images.githubusercontent.com/13156555/124239726-fead4180-dae7-11eb-98d1-1cf6e2fc1aaa.png)

**after**

<img width="1190" alt="image" src="https://user-images.githubusercontent.com/13156555/124239385-a1b18b80-dae7-11eb-8112-d8fe880ae7c6.png">

<img width="600" alt="image" src="https://user-images.githubusercontent.com/13156555/124239862-23a1b480-dae8-11eb-8971-ed84d1eb62f1.png">

---

Fixes Qiskit/platypus#533

