### PR TITLE
Heroku review apps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM alpine:3 AS base
+RUN apk add --update nodejs npm
+
+FROM base AS builder
+WORKDIR /usr/app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY converter/textbook-converter/requirements.txt converter/textbook-converter/
+# py3-pyzmq is needed by pyyaml but pip is not able to compile it.
+RUN apk add --no-cache g++ linux-headers python3 python3-dev py3-pip py3-pyzmq
+RUN python3 -m venv .venv && source .venv/bin/activate
+RUN python3 -m pip install -U pip \
+  && python3 -m pip install -r converter/textbook-converter/requirements.txt
+
+
+COPY converter converter/
+COPY frontend frontend/
+COPY notebooks notebooks/
+COPY shared shared/
+COPY config.yaml ./
+RUN npm run build
+
+FROM base
+WORKDIR /usr/app
+
+COPY --from=builder /usr/app/package*.json ./
+# npm ci --production is not working for some unknown reason
+RUN npm install --production
+COPY server server/
+COPY --from=builder /usr/app/config.yaml ./
+COPY --from=builder /usr/app/public public/
+COPY --from=builder /usr/app/frontend frontend/
+COPY --from=builder /usr/app/notebooks/toc.yaml notebooks/
+
+CMD ["npm", "start"]
+

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ npm run build
 $ npm start
 ```
 
-> _To watch changes and rebuild automatically run with `npm run watch`_
+> _To watch changes and rebuild automatically run with `npm run watch` after installing the dependencies._
 
-After the application has started access the site at: http://localhost:5000/
+After the application has started, access the site at: http://localhost:8080/
+
+> _You can specify the port setting the env variable `PORT`. For instance `PORT=5000 npm start`._

--- a/app.json
+++ b/app.json
@@ -1,0 +1,4 @@
+{
+  "stack": "container"
+}
+

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,4 @@
+build:
+  docker:
+    web: Dockerfile
+

--- a/server/app.ts
+++ b/server/app.ts
@@ -42,4 +42,4 @@ new MathigonStudioApp()
   })
   .course(storageApi)
   .errors()
-  .listen(5000);
+  .listen();


### PR DESCRIPTION
This introduces live pull requests for Platypus via Heroku review apps:
https://devcenter.heroku.com/articles/github-integration-review-apps

Vercel option is not possible since the Express application is importing from TypeScript in `node_modules` folder and that is not currently supported (TypeScript is only supported as a language for the function itself).

Heroku's building and deploying from a Git repository leaves a too big image to upload (>500MiB) so I did everything with a multistage Docker image based on Alpine to remove unnecessary build dependencies.

Heroku Docker does not take advantage of any internal Docker registry so the speed-ups coming from a multistage image are lost and the building process takes time (~15min). Maybe uploading the image to the Docker registry would have a benefit in the overall time.

Also notice that freemium containers (dynos) go to sleep so **before despair, just wait.**

The good things of Heroku review apps are that URLs are predictable:
`https://platypus-prev-pr-<number_of_pr>.herokuapp.com/textbook`
https://platypus-prev-pr-43.herokuapp.com/textbook

Deployment messages are not so fancy as in Vercel but...
<img width="946" alt="image" src="https://user-images.githubusercontent.com/757942/124402659-bd8f7a00-dcff-11eb-9252-8b6899c2216a.png">
