### PR TITLE
build error from Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
         # Change this if you need different/additional build scripts.
         run: npm run build
 
-      - name: Remove Dockerfile
-        # AppEngine error with Dockerfile, remove before deploying
-        run: rm -f Dockerfile
+      - name: Remove Heroku files
+        # AppEngine error with Dockerfile, remove Heroku files before deploying
+        run: rm -f Dockerfile app.json heroku.yml
 
       # https://github.com/google-github-actions/deploy-appengine
       - name: Deploy to AppEngine


### PR DESCRIPTION
the [`Dockerfile` added](https://github.com/qiskit-community/platypus/pull/43) for the Heroku review app is causing AppEngine [build error](https://github.com/qiskit-community/platypus/actions/runs/1005979480).

AppEngine deploy fails if a Dockerfile exists and `runtime` is not set to `custom` (in `app.yaml`). AppEngine cannot be set to ignore `Dockerfile`. it needs to be moved into a subdirectory or removed: https://stackoverflow.com/a/65326626

moving `Dockerfile` to a subdirectory results in Heroku failure because the Docker build context cannot be set. Heroku uses the location of `Dockerfile` (and cannot be configured): https://devcenter.heroku.com/articles/build-docker-images-heroku-yml#known-issues-and-limitations.

therefore, this PR instead just removes the `Dockerfile` right before deploying to AppEngine. this allows the Heroku review app to successful use the `Dockerfile` and AppEngine to deploy without seeing the `Dockerfile`.

(a different possible solution would be to discuss with Mathigon about the possibility of using `runtime: custom` and deploy to AppEngine using same `Dockerfile`)
