### PR TITLE
automatic daily build & deploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - release
+  # run daily at 08:00am UTC (on the default or base branch)
+  # https://crontab.guru/#0_8_*_*_*
+  schedule:
+    - cron: '0 8 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
this PR updates the Build & Release GitHub action so it automatically runs daily at 8 AM UTC (using the `main` branch).
this is the similar to qiskit.org automatic deploy schedule.