### PR TITLE
update menu layering

### DIFF
--- a/frontend/scss/components/textbook__sidebar.scss
+++ b/frontend/scss/components/textbook__sidebar.scss
@@ -8,6 +8,7 @@
   height: calc(100vh - #{$qiskit-navbar-height});
   width: $left-sidebar-width;
   position: fixed;
+  z-index: 1;
 
   @media (max-width: $browser-small) {
     padding-top: 36px;
@@ -16,6 +17,10 @@
 
   .c-content-menu {
     z-index: 150;
+  }
+
+  @include mq($until: medium) {
+    z-index: initial;
   }
 
   @include mq($until: large) {


### PR DESCRIPTION
Fixes https://github.com/Qiskit/qiskit.org/issues/1952

this PR updates the browse all menu so it is properly displayed above main content


**before**:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/13156555/125332834-84ff2a00-e317-11eb-9415-05feee45775a.png">



**after**:

<img width="942" alt="image" src="https://user-images.githubusercontent.com/13156555/125332877-93e5dc80-e317-11eb-96ff-3bf56f530df1.png">


