### PR TITLE
Update megamenu link target attribute

### DIFF
--- a/frontend/vue/components/common/AppMegaDropdownMenu.vue
+++ b/frontend/vue/components/common/AppMegaDropdownMenu.vue
@@ -26,6 +26,7 @@
             <BasicLink
               class="app-mega-dropdown__content-link app-mega-dropdown__content-link_title"
               :url="group.title.url"
+              target="_self"
             >
               <span
                 v-for="(part) in splitTextInHighlightParts(group.title.label)"
@@ -38,6 +39,7 @@
               :key="chapter.label"
               class="app-mega-dropdown__content-link"
               :url="chapter.url"
+              target="_self"
             >
               <span
                 v-for="(part) in splitTextInHighlightParts(chapter.label)"


### PR DESCRIPTION
This PR updates the megamenu links so that they open within the same tab.

I'd love to discuss this, if for whatever reason, this isn't the correct UX.

Thanks!