### PR TITLE
encode `<` in code cells

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -307,7 +307,7 @@ def handle_code_cell(cell, resources):
 
         and indent all lines. Include cell output if configured.
     """
-    formatted_source = cell.source.replace('\n', '\n      ').replace('<', ' < ')
+    formatted_source = cell.source.replace('\n', '\n      ').replace('<', '&lt;')
 
     code_lines = [
         '\n    pre(data-executable="true" data-language="python").\n      ',


### PR DESCRIPTION
in code cells `<` are being wrapped by spaces.
this PR removes the excess spacing and encodes `<` in code cells to properly display in HTML

**before**

<img width="962" alt="image" src="https://user-images.githubusercontent.com/13156555/126387882-48d93019-51cc-4de9-af6f-5d7395458566.png">

**after**

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/13156555/126387939-06573e8f-6b2f-49bf-b4f2-f4fbce92bc1a.png">

Fixes https://github.com/qiskit-community/platypus/issues/68
