### PR TITLE
Enable built-in npm cache from `actions/setup-node`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Load pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: py-${{ hashFiles('converter/textbook-converter/requirements.txt') }}
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -40,6 +34,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.8
+
+      - name: Load pip cache
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: py-${{ hashFiles('converter/textbook-converter/requirements.txt') }}
 
       - name: Install Python dependencies
         run: pip install -r converter/textbook-converter/requirements.txt


### PR DESCRIPTION
Fix #72 

Also:
- Formatted workflow as `Qiskit/qiskit.org`
- Move pip cache step close to the pip install step