### PR TITLE
Update lang switcher trigger content

### DIFF
--- a/frontend/vue/components/common/LanguageSelector.vue
+++ b/frontend/vue/components/common/LanguageSelector.vue
@@ -36,7 +36,7 @@ class Props {
 export default class LanguageSelector extends Vue.with(Props) {
   currentCountryCode = ''
   currentCountryLabel = 'English'
-
+  availableLocales: any
 
   useSelectedLanguage (event: any) {
     const currentHostname = window.location.host
@@ -52,6 +52,21 @@ export default class LanguageSelector extends Vue.with(Props) {
     } else {
       window.location.search = newLanguageCode === 'en' ? '' : '?hl=' + newLanguageCode
     }
+  }
+
+  setLanguage (lang: string) {
+    const result = this.availableLocales.filter((item: { id: string }) => {
+      return item.id === lang
+    })
+
+    this.currentCountryCode = result[0].id
+    this.currentCountryLabel = result[0].key
+  }
+
+  mounted () {
+    const courseLang = document.getElementsByTagName('html')[0].getAttribute('lang') || ''
+    this.availableLocales = this.localesData
+    this.setLanguage(courseLang)
   }
 }
 </script>


### PR DESCRIPTION
This PR adds the dynamic label to the switcher

When user selects language, the user will be taken to a new URL 
at this point, the `LanguageSwitcher` will be aware of which language is selected.

