### PR TITLE
resolve notebook test failure

### DIFF
--- a/notebooks/intro/grover-intro.ipynb
+++ b/notebooks/intro/grover-intro.ipynb
@@ -307,7 +307,7 @@
     }
    ],
    "source": [
-    "with open('examples/3sat.dimacs', 'r') as f:\n",
+    "with open('examples/3sat.dimacs', 'r', encoding='utf8') as f:\n",
     "    dimacs = f.read()\n",
     "print(dimacs)  # let's check the file is as promised"
    ]


### PR DESCRIPTION
update to pylint causing notebook test failure:

```
notebooks/intro/grover-intro.ipynb:cell_1:1:5: W1514: Using open without explicitly specifying an encoding (unspecified-encoding)
```

this is resulting in build failures:

https://github.com/qiskit-community/platypus/runs/3398180166?check_suite_focus=true