### PR TITLE
Fix #52

### DIFF
--- a/frontend/scss/custom.scss
+++ b/frontend/scss/custom.scss
@@ -50,3 +50,9 @@ button span.rangle {
     position: relative;
   }
 }
+
+@media (min-width: $browser-medium) {
+  body > .body {
+    overflow-x: hidden;
+  }
+}


### PR DESCRIPTION
Stops horizontal scrolling for pages with carousels.

[Before](https://learn.qiskit.org/course/introduction/grovers-search-algorithm) & [after](https://platypus-review-pr-119.herokuapp.com/course/introduction/grovers-search-algorithm)