### PR TITLE
fix(code-block): prevent automatic translation

### DIFF
--- a/server/includes/thebe-init.js
+++ b/server/includes/thebe-init.js
@@ -42,7 +42,7 @@ const initializeCodeCells = function () {
   document
     .querySelectorAll('.thebelab-cell')
     .forEach((thebelabCell) => {
-      thebelabCell.classList.add('notranslate')
+      thebelabCell.setAttribute('translate', 'no')
     })
 
   /**


### PR DESCRIPTION
With this PR, the code blocks get a wrapper class that prevents the code from being translated automatically.

### Before

Translation to German includes the code block.

![Screenshot 2021-09-15 at 15 16 31](https://user-images.githubusercontent.com/22047320/133440906-f83e2f99-661c-44ec-bdc0-f9d93a30a51d.png)

### After

Translation ignores the code block.

![Screenshot 2021-09-15 at 15 17 03](https://user-images.githubusercontent.com/22047320/133441039-d4e79a16-5f79-4c7a-be59-456f03527cd9.png)

---

Closes Qiskit/platypus#459