### PR TITLE
Parse index titles

### DIFF
--- a/converter/postbuild.ts
+++ b/converter/postbuild.ts
@@ -50,7 +50,9 @@ const replaceEquationByMathjax = function(title, mathjaxEquation) {
 
 const findIndexFromCourse = function(path) {
   const indexCourse = loadYAML(path)
-  if (Object.entries(indexCourse).length === 0) return undefined
+  if (Object.entries(indexCourse).length === 0) {
+    return undefined
+  }
   return indexCourse
 }
 
@@ -109,7 +111,9 @@ const parseSection = function(section, store) {
   }
 
   const code = findEquationFromTitle(section.title)
-  if(!code) return section
+  if(!code) {
+    return section
+  }
 
   const codeCleaned = parseParagraph(code[0])
   const codeId = getId(codeCleaned)
@@ -130,7 +134,9 @@ const updateIndexYaml = async function() {
   const indexCoursePaths = COURSES.map(courseId => getIndexPath(courseId))
   const indexCourses = indexCoursePaths.map(indexCoursePath => findIndexFromCourse(indexCoursePath))
   const indexCoursesParsed = indexCourses.map(index => {
-    if(!index) return undefined
+    if(!index) {
+      return undefined
+    }
 
     const newIndex = {}
     const moduleIds = Object.keys(index)
@@ -211,31 +217,12 @@ const getId = function(code) {
 
 /** Mathigon methods from renderer.js */
 
-/** This method differs from the original to avoid the GitHub Emoji replace */
+/** This method differs from the original to avoid the mathigon widgets and GitHub Emoji replaces */
 const parseParagraph = function(text) {
-  text = inlineBlanks(text);
   text = inlineEquations(text);
-  text = inlineVariables(text);
 
   // Replace non-breaking space and escaped $s.
   return text.replace(/\\ /g, '&nbsp;').replace(/\\\$/g, '$');
-}
-
-/** Render inline blank elements using [[a|b]]. */
-function inlineBlanks(text) {
-  return text.replace(/\[\[([^\]]+)]]/g, (x, body) => {
-    const choices = body.split('§§');  // Replacement for |s because of tables.
-
-    if (choices.length === 1) {
-      const [_1, value, _2, hint] = (/^([^(]+)(\((.*)\))?\s*$/g).exec(body);
-      const hintAttr = hint ? `hint="${hint}"` : '';
-      return `<x-blank solution="${value}" ${hintAttr}></x-blank>`;
-
-    } else {
-      const choiceEls = choices.map(c => `<button class="choice">${c}</button>`);
-      return `<x-blank-mc>${choiceEls.join('')}</x-blank-mc>`;
-    }
-  });
 }
 
 /** Render inline LaTeX equations using $x^2$. */
@@ -247,12 +234,6 @@ function inlineEquations(text) {
   return text.replace(/(^|[^\\])\$([^{][^$]*?)\$($|[^\w])/g, (_, prefix, body, suffix) => {
     return prefix + decode(body) + suffix;
   });
-}
-
-/** Render inline variables using ${x}. */
-function inlineVariables(text) {
-  return text.replace(/\${([^}]+)}{([^}]+)}/g, '<x-var bind="$2">${$1}</x-var>')
-      .replace(/\${([^}]+)}(?!<\/x-var>)/g, '<span class="var">${$1}</span>');
 }
 
 translationsLanguages.forEach(async(language) => {


### PR DESCRIPTION
Fix https://github.com/Qiskit/qiskit.org/issues/2238
Fix https://github.com/qiskit-community/platypus/issues/154

### Summary
This PR tries to fix that the mathjax formulas are not being rendered correctly in the index. The solution basically consist in read the `index.yaml` for each course and parse it the same way that mathigon does with the content.

Items to consider:
- For the mathjax parser instead to use mathjax directly we use the cache from mathigon to simplify the process ([here](https://github.com/qiskit-community/platypus/pull/189/files#diff-9be3fdcfe464115ff06b573e291eee5a2af64e0048424069cdbb620055cf6717R124))

### Before / After Example 1:
<img width="200" alt="Screenshot 2021-10-27 at 16 33 22" src="https://user-images.githubusercontent.com/9059044/139091256-9daba247-f0c7-47b1-a2d9-73d99e2ff02f.png">
<img width="200" alt="Screenshot 2021-10-27 at 16 53 00" src="https://user-images.githubusercontent.com/9059044/139091268-bc7a4bb4-8cbb-4771-90b5-d34295679d73.png">

### Before / After Example 2:
<img width="200" alt="Screenshot 2021-10-27 at 16 33 49" src="https://user-images.githubusercontent.com/9059044/139091264-8f6b5c41-1f83-47da-8274-e747bf6a1868.png">
<img width="200" alt="Screenshot 2021-10-27 at 16 53 25" src="https://user-images.githubusercontent.com/9059044/139091273-22641462-0b8d-46b3-861a-65a66c883fc6.png">
