### PR TITLE
Remove abdonrd as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @vabarbosa @techtolentino @korgan00 @eddybrando @abdonrd @tansito
+* @vabarbosa @techtolentino @korgan00 @eddybrando @tansito


### PR DESCRIPTION
I don't need to be strictly a reviewer for all PRs.
And so I reduce the level of email notifications.
I still watching the repo, so I see the activity in the [GitHub notifications](https://github.com/notifications).