### PR TITLE
Fix mega-menu keyboard issue 

### DIFF
--- a/frontend/scss/custom.scss
+++ b/frontend/scss/custom.scss
@@ -38,6 +38,10 @@ div.text_cell_render > p > a > img {
 
 body > .body {
   margin-top: $qiskit-navbar-height;
+  // prevent mobile resizing
+  @include mq($until: medium) {
+    overflow: hidden;
+  }
 }
 
 button span.rangle {

--- a/frontend/ts/leftsidebar.ts
+++ b/frontend/ts/leftsidebar.ts
@@ -46,7 +46,14 @@ const initLeftSidebar = function () {
     parentContainer?.classList?.add(hiddenPanelClass)
   }
 
-  window.addEventListener('resize', collapseMobileMenu)
+  // prevent mobile resizing
+  let windowInnerWidth = window.innerWidth
+  window.addEventListener('resize', () => {
+    if (windowInnerWidth !== window.innerWidth) {
+      windowInnerWidth = window.innerWidth
+      collapseMobileMenu()
+    }
+  })
 }
 
 const toggleLanguagePicker = function () {


### PR DESCRIPTION
Fixes https://github.com/Qiskit/platypus/issues/247

- adds code to prevent window resizing on mobile
- this issue was specific to Android devices

**Android Emulator showing the keyboard persists**
https://user-images.githubusercontent.com/6276074/149399307-ff2ad2d6-d34b-4367-a580-5661f119476b.mov


