### PR TITLE
Fix release.yml quotes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   build-test-release:
     # Run only from the original repository
     # Because this job requires secrets, which cannot be shared with forks
-    if: github.repository == "Qiskit/platypus"
+    if: github.repository == 'Qiskit/platypus'
 
     name: Build, Test, and Release
 


### PR DESCRIPTION
Seems like double quotes doesn't work on the `if` condition:

https://github.com/Qiskit/qiskit.org/actions/runs/1708639108