### PR TITLE
Disable Python in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     ":maintainLockFilesWeekly"
   ],
   "rangeStrategy": "bump",
+  "python": {
+    "enabled": false
+  },
   "prConcurrentLimit": 5,
   "schedule": [
     "every weekend"


### PR DESCRIPTION
It helps to reduce the Renovate PRs.

As the idea is to convert the Python package to Node.js:
- https://github.com/Qiskit/platypus/issues/321