### PR TITLE
update workflow naming

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,11 +1,11 @@
-name: Preview
+name: Preview (clean)
 
 on:
   pull_request:
     types: [closed]
 
 jobs:
-  code-engine:
+  teardown:
     # Run only from the original repository
     # Because this job requires secrets, which cannot be shared with forks
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,10 +1,10 @@
-name: Preview
+name: Preview (deploy)
 
 on:
   pull_request:
 
 jobs:
-  code-engine:
+  setup:
     # Run only from the original repository
     # Because this job requires secrets, which cannot be shared with forks
     if: github.event.pull_request.head.repo.full_name == github.repository


### PR DESCRIPTION
related to https://github.com/Qiskit/gh-actions/issues/16

this PR updates the workflow and action naming to be more appropriate and distinguishable.

currently both the creating and the destroying preview workflow have the same name `Preview` which can cause confusion when reviewing the workflows in the **Actions** tab

related https://github.com/Qiskit/qiskit.org/pull/2446
