### PR TITLE
Typo fix in chapter 6.7 - Hamiltonian Tomography

### DIFF
--- a/notebooks/ch-quantum-hardware/hamiltonian-tomography.ipynb
+++ b/notebooks/ch-quantum-hardware/hamiltonian-tomography.ipynb
@@ -52,7 +52,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Fitting Fuctions <a class=\"anchor\" id=\"fitting-functions\"></a>\n",
+    "## Fitting Functions <a class=\"anchor\" id=\"fitting-functions\"></a>\n",
     "\n",
     "In order to extract the coefficients $a_{\\mu}, b_{\\nu}$, we need to know what function we expect to fit to the measurement data.  The data we will be looking at will be the expectation value of Pauli operators as a function of pulse duration.  In the Heisenberg picture of quantum mechanics, the evolution of the expection value of an operator can be given as\n",
     "\n",
@@ -1076,7 +1076,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1090,7 +1090,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.10.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This is a partial fix for [this issue](https://github.com/qiskit-community/qiskit-textbook/issues/1358) in the old qiskit-textbook repo.