### PR TITLE
Use main branch for preview action

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -8,7 +8,7 @@ jobs:
     # Run only from the original repository
     # Because this job requires secrets, which cannot be shared with forks
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@platypus-user-account
+    uses: Qiskit/gh-actions/.github/workflows/code-engine-preview.yml@main
     with:
       code_engine_project: platypus-preview
       docker_image_name: platypus


### PR DESCRIPTION
From #681 use now that the PR is merged the new `main` preview structure from gh-action