### PR TITLE
Improve SSO management in prod and staging

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -15,6 +15,6 @@ jobs:
     secrets:
       ibmcloud_account: ${{ secrets.IBMCLOUD_ACCOUNT }}
       ibmcloud_api_key: ${{ secrets.IBMCLOUD_API_KEY }}
-      ibmid_client_id: ${{ secrets.IBMID_CLIENT_ID }}
-      ibmid_client_secret: ${{ secrets.IBMID_CLIENT_SECRET }}
+      ibmid_client_id: ${{ secrets.STAGING_IBMID_CLIENT_ID }}
+      ibmid_client_secret: ${{ secrets.STAGING_IBMID_CLIENT_SECRET }}
       mongodb_uri: ${{ secrets.STAGING_MONGODB_URI }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: pip install -r converter/textbook-converter/requirements.txt -r converter/textbook-converter/requirements-test.txt
 
       - name: Secrets
-        run: npm run setup:secrets -- --mongo ${{ secrets.PRODUCTION_MONGODB_URI }} --ibmClientId ${{ secrets.IBMID_CLIENT_ID }} --ibmClientSecret ${{ secrets.IBMID_CLIENT_SECRET }}
+        run: npm run setup:secrets -- --mongo ${{ secrets.PRODUCTION_MONGODB_URI }} --ibmClientId ${{ secrets.PRODUCTION_IBMID_CLIENT_ID }} --ibmClientSecret ${{ secrets.PRODUCTION_IBMID_CLIENT_SECRET }} --googleClientId ${{ secrets.PRODUCTION_GOOGLE_CLIENT_ID }} --googleClientSecret ${{ secrets.PRODUCTION_GOOGLE_CLIENT_SECRET }}
 
       - name: Notebook tests
         run: npm run test:nb

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # platypus
 
 This repository is home of the new [Qiskit Textbook (beta)](https://qiskit.org/textbook-beta/).
-this is a change
+
 The previous version of the Qiskit Textbook textbook can be found [here](https://github.com/qiskit-community/qiskit-textbook).
 
 The textbook is intended for use as a university quantum algorithms course supplement as well as a guide for self-learners who are interested in learning quantum programming.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # platypus
 
 This repository is home of the new [Qiskit Textbook (beta)](https://qiskit.org/textbook-beta/).
-
+this is a change
 The previous version of the Qiskit Textbook textbook can be found [here](https://github.com/qiskit-community/qiskit-textbook).
 
 The textbook is intended for use as a university quantum algorithms course supplement as well as a guide for self-learners who are interested in learning quantum programming.


### PR DESCRIPTION
Fix #703 

The idea will be to have:

- Google and IBMID in production
- IBMID in staging (we can not configure every redirection in google because we don't have an easy access to the qiskit account)
- Google to develop in local