### PR TITLE
Fixed the misleading link of chapter 6.2

### DIFF
--- a/notebooks/ch-quantum-hardware/accessing_higher_energy_states.ipynb
+++ b/notebooks/ch-quantum-hardware/accessing_higher_energy_states.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "In most quantum algorithms/applications, computations are carried out over a 2-dimensional space spanned by $|0\\rangle$ and $|1\\rangle$. In IBM's hardware, however, there also exist higher energy states which are not typically used. The focus of this section is to explore these states using Qiskit Pulse. In particular, we demonstrate how to excite the $|2\\rangle$ state and build a discriminator to classify the $|0\\rangle$, $|1\\rangle$ and $|2\\rangle$ states.\n",
     "\n",
-    "We recommend reviewing the prior [chapter](https://qiskit.org/textbook/ch-quantum-hardware/calibrating-qubits-openpulse.html) before going through this notebook. We also suggest reading the Qiskit Pulse specifications (Ref [1](#refs)). "
+    "We recommend reviewing the prior [chapter](https://learn.qiskit.org/course/quantum-hardware-pulses/calibrating-qubits-using-qiskit-pulse) before going through this notebook. We also suggest reading the Qiskit Pulse specifications (Ref [1](#refs)). "
    ]
   },
   {
@@ -2412,7 +2412,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.8.5"
   },
   "name": "accessing_higher_energy_states.ipynb",
   "widgets": {


### PR DESCRIPTION
I have changed the link to https://learn.qiskit.org/course/quantum-hardware-pulses/calibrating-qubits-using-qiskit-pulse instead of https://qiskit.org/textbook/ch-quantum-hardware/calibrating-qubits-openpulse.html as per Issue #718 