### PR TITLE
ci: only rebase Renovate PRs manually

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,7 @@
     "enabled": false
   },
   "prConcurrentLimit": 5,
+  "rebaseWhen": "never",
   "schedule": [
     "every weekend"
   ]


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

As discussed in our dev team meeting, the Renovate bot rebases PRs frequently, using our CI resources.

This changes its configuration to avoid the automatic rebases. Manual rebasing is still possible.

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

Changed the configuration following the documentation: https://docs.renovatebot.com/configuration-options/#rebasewhen
