### PR TITLE
Fix support to the last LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "setup:secrets": "mgon-secrets"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=14 <17"
   },
   "dependencies": {
     "@carbon/colors": "^10.35.0",


### PR DESCRIPTION
Fix #730 

Seems that we were deploying with Node v17 which is not supported by mongo:
https://github.com/Automattic/mongoose/issues/11377