### PR TITLE
Added CSRF implementation

### DIFF
--- a/frontend/vue/components/UserAccount/EndUserLicenseAgreementLayout.vue
+++ b/frontend/vue/components/UserAccount/EndUserLicenseAgreementLayout.vue
@@ -79,7 +79,10 @@ export default defineComponent({
       ev.preventDefault()
       const requestOptions = {
         method: "POST",
-        headers: { "Content-Type": "application/json" }
+        headers: { 
+          "Content-Type": "application/json"
+        },
+        body: JSON.stringify({ _csrf: window.csrfToken })
       }
       fetch("/profile/accept-policies", requestOptions)
         .then(response => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -61,7 +61,7 @@ const getCourseData = async function (req: Request) {
 new MathigonStudioApp()
   .get('/health', (req, res) => res.status(200).send('ok')) // Server Health Checks
   .secure()
-  .setup({ sessionSecret: 'project-platypus-beta', csrfBlocklist: ['/profile/accept-policies'] })
+  .setup({ sessionSecret: 'project-platypus-beta' })
   // .redirects({'/login': '/signin'})
   .accounts()
   .redirects({


### PR DESCRIPTION
Fix #733 

To execute **POST** requests from the front we need to pass in the body the token with the key `_csrf`.