### PR TITLE
update binder repo

### DIFF
--- a/frontend/vue/components/CodeExercise/KernelManager.ts
+++ b/frontend/vue/components/CodeExercise/KernelManager.ts
@@ -38,7 +38,7 @@ const targetEnvironment = window.location.hostname.includes('localhost') ? 'stag
 
 export const serverOptions: IServerOptions = {
   binderOptions: {
-    repo: 'qiskit-community/platypus-binder',
+    repo: 'qiskit/platypus-binder',
     ref: targetEnvironment,
     binderUrl: 'https://mybinder.org',
     savedSession: {


### PR DESCRIPTION
## Changes

binder repo was transferred from https://github.com/qiskit-community/platypus-binder to https://github.com/Qiskit/platypus-binder

this PR updates the reference to the binder repo

## Implementation details

binder repo config updated point to new location

