### PR TITLE
Require user acct to access syllabus create page

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -213,6 +213,10 @@ const start = () => {
       })
     })
     .get('/syllabus/create', (req, res) => {
+      if (!req.user) {
+        return res.redirect('/signin')
+      }
+
       res.render('syllabusCreate')
     })
     .get('/syllabus', FindSyllabiController)


### PR DESCRIPTION
## Changes
Fixes https://github.com/Qiskit/platypus/issues/839

## Implementation details
- update `app.ts` to require a user account for the `syllabus/create` route

## How to read this PR
- review `app.ts`
- try to access `/syllabus/create` route with no account
- see that you're redirected to the `/signin` page

## Screenshots

https://user-images.githubusercontent.com/6276074/161137342-a0549f8e-6a5f-443f-91e6-bc735329d979.mov


