### PR TITLE
Specify carbon-components version

### DIFF
--- a/server/templates/head.pug
+++ b/server/templates/head.pug
@@ -16,7 +16,7 @@ meta(property="og:image" content="https://learn.qiskit.org/images/qiskit-logo-he
 link(rel="canonical" href="https://learn.qiskit.org/textbook")
 
 link(rel="stylesheet" data-style="course" href="/course.css")
-link(rel="stylesheet" href="https://unpkg.com/carbon-components/css/carbon-components.min.css")
+link(rel="stylesheet" href="https://unpkg.com/carbon-components@10.56.0/css/carbon-components.min.css")
 link(rel="stylesheet" data-style="main" href="/main.css")
 
 title= title


### PR DESCRIPTION
## Changes
Fixes #870 

## Implementation details
- Following guidance from the Carbon team, commented [here](https://github.com/carbon-design-system/carbon/issues/11129#issuecomment-1086125085)
- Specified the version in `head` template


## How to read this PR
- See how we specify carbon-components v 10.56.0
- See branch and notice the type/spacing is correct

## Screenshots (back to normal)
![Screen Shot 2022-04-01 at 12 23 29 PM (2)](https://user-images.githubusercontent.com/6276074/161328552-3224fff2-b926-4a48-93c3-b1bd44e17fec.png)

