### PR TITLE
Remove unnecessary `#` hash characters

### DIFF
--- a/notebooks/ch-algorithms/grover.ipynb
+++ b/notebooks/ch-algorithms/grover.ipynb
@@ -1286,8 +1286,8 @@
     "result = sv_sim.run(grover_circuit).result()\n",
     "statevec = result.get_statevector()\n",
     "statevec\n",
-    "#from qiskit_textbook.tools import vector2latex\n",
-    "#vector2latex(statevec, pretext=\"|\\\\psi\\\\rangle =\")"
+    "from qiskit_textbook.tools import vector2latex\n",
+    "vector2latex(statevec, pretext=\"|\\\\psi\\\\rangle =\")"
    ]
   },
   {

--- a/notebooks/ch-algorithms/grover.ipynb
+++ b/notebooks/ch-algorithms/grover.ipynb
@@ -1285,8 +1285,8 @@
     "sv_sim = Aer.get_backend('statevector_simulator')\n",
     "result = sv_sim.run(grover_circuit).result()\n",
     "statevec = result.get_statevector()\n",
-    "from qiskit_textbook.tools import vector2latex\n",
-    "vector2latex(statevec, pretext=\"|\\\\psi\\\\rangle =\")"
+    "from qiskit.visualization import array_to_latex\n",
+    "array_to_latex(statevec, prefix=\"|\\\\psi\\\\rangle =\")"
    ]
   },
   {

--- a/notebooks/ch-algorithms/grover.ipynb
+++ b/notebooks/ch-algorithms/grover.ipynb
@@ -1285,7 +1285,6 @@
     "sv_sim = Aer.get_backend('statevector_simulator')\n",
     "result = sv_sim.run(grover_circuit).result()\n",
     "statevec = result.get_statevector()\n",
-    "statevec\n",
     "from qiskit_textbook.tools import vector2latex\n",
     "vector2latex(statevec, pretext=\"|\\\\psi\\\\rangle =\")"
    ]


### PR DESCRIPTION
## Changes

Fixes #354 

## Implementation details

Removed characters that were commenting out code

## How to read this PR

- Review extra hash characters that were removed
- try to visit the the [Grovers Algorithm chapter](https://platypus-pr-898.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/ch-algorithms/grovers-algorithm) in the preview branch
- run the code in the 2.1.1 cell and see the error is gone

## Screenshots

![Screen Shot 2022-04-12 at 9 54 48 AM](https://user-images.githubusercontent.com/6276074/163018394-3c3c5fe6-b457-4942-b9da-8af696ce3e40.png)

## Note
This is my first attempt at fixing one of these code cells; I based the removal of the `#` characters on how I see the `vector2latex` used in other notebooks... hopefully this is right.