### PR TITLE
Removed references to quantum Boltzmann machines (fixes #711)

### DIFF
--- a/notebooks/quantum-machine-learning/unsupervised.ipynb
+++ b/notebooks/quantum-machine-learning/unsupervised.ipynb
@@ -15,9 +15,9 @@
     "\n",
     "![](images/unsupervised/hero.png)\n",
     "\n",
-    "There are a number of classical and quantum algorithms for different unsupervised learning tasks such as principal component analysis (PCA), clustering, variational autoencoders (VAE), generative adversarial networks (GAN) and boltzmann machines. In the following page we will focus on GANs. \n",
+    "There are a number of classical and quantum algorithms for different unsupervised learning tasks such as principal component analysis (PCA), clustering, variational autoencoders (VAE), and generative adversarial networks (GAN). In the following page we will focus on GANs. \n",
     "\n",
-    "The focus of much recent research in near term quantum unsupervised learning has been on the quantum analogues of GANs and Boltzmann machines which are covered in detail in the linked sections:\n",
+    "The focus of much recent research in near term quantum unsupervised learning has been on the quantum analogues of GANs, which are covered in detail in the linked sections:\n",
     "\n",
     "## Quantum generative adversarial networks\n",
     "\n",
@@ -30,21 +30,6 @@
     "$G_\\theta$ and $D_\\phi$ can both be classical or quantum machine learning models.\n",
     "\n",
     "This is covered in the [next page](./quantum-generative-adversarial-networks)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Quantum Boltzmann Machines\n",
-    "\n",
-    "![](images/qbm/qbm-2.svg)\n",
-    "\n",
-    "Given data points from a probability distribution the QBM seeks to learn the distribution $P_v$ that resembles $P_v^\\text{data}$. For the parameters $\\vec{w}, \\vec{b}$ the goal is to maximize the log likelihood $L = \\sum_v P_v^\\text{data} \\log P_v $, where $P_v = \\frac{e^{-E_v}}{\\sum_h e^{-E_h}}$ and the energy is represented as the Ising model $E_v = - \\sum_i b_i v_i - \\sum_{i, j} w_{i, j} v_i v_j$.\n",
-    "\n",
-    "This is covered in the [quantum Boltzmann machines page](./quantum-boltzmann-machines).\n",
-    "\n",
-    "Both methods are capable of working with classical and quantum data. As before, when working with classical data there are a number of strategies to define the encoding scheme, as outlined in the [data encoding page](./data-encoding)."
    ]
   },
   {


### PR DESCRIPTION
## Changes

Removed references to the _quantum Boltzmann machines_ page, which got removed last minute, so is not in the course.

Page is still being worked on, so we may be able to revert this commit when it's merged.