### PR TITLE
Refactor `/account` routes

### DIFF
--- a/frontend/vue/components/UserAccount/UserAccountLayout.vue
+++ b/frontend/vue/components/UserAccount/UserAccountLayout.vue
@@ -7,16 +7,16 @@
         </h2>
       </div>
       <div class="user-account__section-nav__link-list">
-        <AppLink
-          v-for="{displayName, hash} in sectionList"
-          :key="hash"
+        <BasicLink
+          v-for="{displayName, url} in sectionList"
+          :key="url"
           class="user-account__section-nav__link-list__link"
-          :class="{'user-account__section-nav__link-list__link_active': activeSection === hash}"
-          :url="hash"
+          :class="{'user-account__section-nav__link-list__link_active': activeSection === url}"
+          :url="url"
           target="_self"
         >
           {{ displayName }}
-        </AppLink>
+        </BasicLink>
         <BasicLink
           class="user-account__section-nav__link-list__link"
           :url="logoutUrl"
@@ -33,22 +33,22 @@
       @bx-dropdown-selected="switchPanel($event)"
     >
       <bx-dropdown-item
-        v-for="{displayName, hash} in sectionList"
-        :key="hash"
+        v-for="{displayName, url} in sectionList"
+        :key="url"
         class="user-account__section-dropdown__item"
-        :value="hash"
+        :value="url"
       >
         {{ displayName }}
       </bx-dropdown-item>
     </bx-dropdown>
     <section class="user-account__section-container">
-      <div v-if="activeSection === sectionList[0].hash">
+      <div v-if="activeSection === sectionList[0].url">
         <UserProgress />
       </div>
-      <div v-else-if="activeSection === sectionList[1].hash">
+      <div v-else-if="activeSection === sectionList[1].url">
         <ClassroomSection />
       </div>
-      <div v-if="activeSection === sectionList[2].hash">
+      <div v-if="activeSection === sectionList[2].url">
         <PrivacySection />
         <DeleteUserDataSection />
       </div>
@@ -58,7 +58,6 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue-demi'
-import AppLink from '../common/AppLink.vue'
 import BasicLink from '../common/BasicLink.vue'
 import PrivacySection from './PrivacySection.vue'
 import UserProgress from './UserProgress.vue'
@@ -68,7 +67,6 @@ import ClassroomSection from './ClassroomSection.vue'
 export default defineComponent({
   name: 'UserAccountLayout',
   components: {
-    AppLink,
     BasicLink,
     PrivacySection,
     UserProgress,
@@ -85,15 +83,15 @@ export default defineComponent({
       sectionList: [
         {
           displayName: this.$translate('Learning'),
-          hash: '#MyLearning'
+          url: '/account'
         },
         {
           displayName: this.$translate('Classroom'),
-          hash: '#Classroom'
+          url: '/account/classroom'
         },
         {
           displayName: this.$translate('Privacy'),
-          hash: '#Privacy'
+          url: '/account/privacy'
         }
       ],
       logoutUrl: '/logout'
@@ -112,14 +110,11 @@ export default defineComponent({
     }
   },
   mounted () {
-    this.activeSection = window.location.hash || this.sectionList[0].hash
-    window?.addEventListener('hashchange', () => {
-      this.activeSection = window.location.hash
-    }, false)
+    this.activeSection = window.location.pathname || this.sectionList[0].url
   },
   methods: {
     switchPanel (event: CustomEvent) {
-      window.location.hash = event.detail.item.value
+      window.location.pathname = event.detail.item.value
     }
   }
 })

--- a/server/app.ts
+++ b/server/app.ts
@@ -98,8 +98,8 @@ const getAccountData = async (req: Request, res: Response) => {
   const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
 
   const userMockData = {
-    firstName: req.user?.firstName,
-    lastName: req.user?.lastName
+    firstName: req.user.firstName,
+    lastName: req.user.lastName
   }
 
   const progressData = await getUserProgressData(req)

--- a/server/app.ts
+++ b/server/app.ts
@@ -172,6 +172,66 @@ const start = () => {
         translationsJSON
       })
     })
+    .get('/account/classroom', async (req, res) => {
+      if (!req.user) {
+        return res.redirect('/signin')
+      }
+      if (req.user && !req.user.acceptedPolicies) {
+        return res.redirect('/eula')
+      }
+
+      const lang = req.locale.id || 'en'
+      const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
+
+      const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
+
+      const userMockData = {
+        firstName: req.user?.firstName,
+        lastName: req.user?.lastName
+      }
+
+      const progressData = await getUserProgressData(req)
+
+      res.render('userAccount', {
+        config: CONFIG,
+        userData: userMockData,
+        progressJSON: JSON.stringify(progressData),
+        lang,
+        privacyPolicyMD,
+        translationsJSON
+      })
+    })
+
+    .get('/account/privacy', async (req, res) => {
+      if (!req.user) {
+        return res.redirect('/signin')
+      }
+      if (req.user && !req.user.acceptedPolicies) {
+        return res.redirect('/eula')
+      }
+
+      const lang = req.locale.id || 'en'
+      const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
+
+      const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
+
+      const userMockData = {
+        firstName: req.user?.firstName,
+        lastName: req.user?.lastName
+      }
+
+      const progressData = await getUserProgressData(req)
+
+      res.render('userAccount', {
+        config: CONFIG,
+        userData: userMockData,
+        progressJSON: JSON.stringify(progressData),
+        lang,
+        privacyPolicyMD,
+        translationsJSON
+      })
+    })
+
     .get('/eula', (req, res) => {
       if (!req.user) {
         return res.redirect('/signin')

--- a/server/app.ts
+++ b/server/app.ts
@@ -84,6 +84,36 @@ const getUserProgressData = async (req: Request) => {
   return progress
 }
 
+const getAccountData = async (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.redirect('/signin')
+  }
+  if (req.user && !req.user.acceptedPolicies) {
+    return res.redirect('/eula')
+  }
+
+  const lang = req.locale.id || 'en'
+  const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
+
+  const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
+
+  const userMockData = {
+    firstName: req.user?.firstName,
+    lastName: req.user?.lastName
+  }
+
+  const progressData = await getUserProgressData(req)
+
+  res.render('userAccount', {
+    config: CONFIG,
+    userData: userMockData,
+    progressJSON: JSON.stringify(progressData),
+    lang,
+    privacyPolicyMD,
+    translationsJSON
+  })
+}
+
 const start = () => {
   new MathigonStudioApp()
     .get('/health', (req, res) => res.status(200).send('ok')) // Server Health Checks
@@ -143,95 +173,9 @@ const start = () => {
 
       res.redirect('/logout')
     })
-    .get('/account', async (req, res) => {
-      if (!req.user) {
-        return res.redirect('/signin')
-      }
-      if (req.user && !req.user.acceptedPolicies) {
-        return res.redirect('/eula')
-      }
-
-      const lang = req.locale.id || 'en'
-      const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
-
-      const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
-
-      const userMockData = {
-        firstName: req.user?.firstName,
-        lastName: req.user?.lastName
-      }
-
-      const progressData = await getUserProgressData(req)
-
-      res.render('userAccount', {
-        config: CONFIG,
-        userData: userMockData,
-        progressJSON: JSON.stringify(progressData),
-        lang,
-        privacyPolicyMD,
-        translationsJSON
-      })
-    })
-    .get('/account/classroom', async (req, res) => {
-      if (!req.user) {
-        return res.redirect('/signin')
-      }
-      if (req.user && !req.user.acceptedPolicies) {
-        return res.redirect('/eula')
-      }
-
-      const lang = req.locale.id || 'en'
-      const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
-
-      const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
-
-      const userMockData = {
-        firstName: req.user?.firstName,
-        lastName: req.user?.lastName
-      }
-
-      const progressData = await getUserProgressData(req)
-
-      res.render('userAccount', {
-        config: CONFIG,
-        userData: userMockData,
-        progressJSON: JSON.stringify(progressData),
-        lang,
-        privacyPolicyMD,
-        translationsJSON
-      })
-    })
-
-    .get('/account/privacy', async (req, res) => {
-      if (!req.user) {
-        return res.redirect('/signin')
-      }
-      if (req.user && !req.user.acceptedPolicies) {
-        return res.redirect('/eula')
-      }
-
-      const lang = req.locale.id || 'en'
-      const translationsJSON = JSON.stringify(TRANSLATIONS[lang] || {})
-
-      const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
-
-      const userMockData = {
-        firstName: req.user?.firstName,
-        lastName: req.user?.lastName
-      }
-
-      const progressData = await getUserProgressData(req)
-
-      res.render('userAccount', {
-        config: CONFIG,
-        userData: userMockData,
-        progressJSON: JSON.stringify(progressData),
-        lang,
-        privacyPolicyMD,
-        translationsJSON
-      })
-    })
-
+    .get('/account', getAccountData)
+    .get('/account/classroom', getAccountData)
+    .get('/account/privacy', getAccountData)
     .get('/eula', (req, res) => {
       if (!req.user) {
         return res.redirect('/signin')

--- a/server/app.ts
+++ b/server/app.ts
@@ -88,7 +88,7 @@ const getAccountData = async (req: Request, res: Response) => {
   if (!req.user) {
     return res.redirect('/signin')
   }
-  if (req.user && !req.user.acceptedPolicies) {
+  if (!req.user.acceptedPolicies) {
     return res.redirect('/eula')
   }
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -97,7 +97,7 @@ const getAccountData = async (req: Request, res: Response) => {
 
   const privacyPolicyMD = loadLocaleRawFile('privacy-policy.md', lang)
 
-  const userMockData = {
+  const loggedInUser = {
     firstName: req.user.firstName,
     lastName: req.user.lastName
   }
@@ -106,7 +106,7 @@ const getAccountData = async (req: Request, res: Response) => {
 
   res.render('userAccount', {
     config: CONFIG,
-    userData: userMockData,
+    userData: loggedInUser,
     progressJSON: JSON.stringify(progressData),
     lang,
     privacyPolicyMD,


### PR DESCRIPTION
## Changes

Fixes #867 

## Implementation details
- add new routes for `/account/classroom`, `/account/privacy`
- replaced `hash` based approach, with `pathname` for `activeSection` matching
- replaced `AppLink` w/ `BasicLink` for account sidebar

## How to read this PR
- review `getAccountData` in `app.ts` to see if this is the right approach
- review UI (or screen grab below)

## Screenshots

https://user-images.githubusercontent.com/6276074/164274419-1c464477-2e55-454c-a4ad-c47dc164780c.mov


## Notes
- I'm making this PR into the `feature/professor-syllabus` branch, but please let me know if this should come _after_ that branch is merged. In other words, should this be part of a later Syllabus 1.1 milestone?
- This PR does **not** handle the `/syllabus` related routes...  I think that needs to be considered in separate refactor, along with [this issue](https://github.com/Qiskit/platypus/issues/837) 