### PR TITLE
Fixed as required only the name and instructor

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -2,7 +2,7 @@
 // Project Platypus
 // =============================================================================
 
-import { Request, Response, NextFunction  } from 'express'
+import { Request, Response, NextFunction } from 'express'
 import { customAlphabet } from 'nanoid/non-secure'
 
 import { MathigonStudioApp } from '@mathigon/studio/server/app'

--- a/server/modules/syllabus/commands/create-syllabus/create-syllabus-dto.ts
+++ b/server/modules/syllabus/commands/create-syllabus/create-syllabus-dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsEmail, IsString, MaxLength, IsNotEmpty, IsOptional, validateOrReject } from 'class-validator'
+import { IsArray, IsString, MaxLength, IsNotEmpty, IsOptional, validateOrReject } from 'class-validator'
 import { Syllabus } from '../../domain/syllabus'
 import { SyllabusCourse } from '../../domain/syllabus-course'
 import { SyllabusCode, generate } from '../../domain/syllabus-code'
@@ -18,8 +18,8 @@ export class CreateSyllabusDto implements CreateSyllabus {
 
   @MaxLength(255)
   @IsString()
-  @IsNotEmpty()
-  readonly location!: string
+  @IsOptional()
+  readonly location?: string
 
   @MaxLength(255)
   @IsString()
@@ -28,19 +28,19 @@ export class CreateSyllabusDto implements CreateSyllabus {
 
   @IsString()
   @IsOptional()
-  readonly officeHours!: string
+  readonly officeHours?: string
 
   @IsString()
   @IsOptional()
-  readonly classHours!: string
+  readonly classHours?: string
 
   @MaxLength(64)
   @IsOptional()
-  readonly email!: string
+  readonly email?: string
 
   @IsArray()
-  @IsNotEmpty()
-  readonly courseList!: SyllabusCourse[]
+  @IsOptional()
+  readonly courseList?: SyllabusCourse[]
 
   @IsArray()
   @IsNotEmpty()

--- a/server/modules/syllabus/commands/update-syllabus/update-syllabus-dto.ts
+++ b/server/modules/syllabus/commands/update-syllabus/update-syllabus-dto.ts
@@ -19,7 +19,7 @@ export class UpdateSyllabusDto implements Syllabus {
   @MaxLength(255)
   @IsString()
   @IsOptional()
-  readonly location: string
+  readonly location?: string
 
   @MaxLength(255)
   @IsString()
@@ -28,20 +28,20 @@ export class UpdateSyllabusDto implements Syllabus {
 
   @IsString()
   @IsOptional()
-  readonly officeHours: string
+  readonly officeHours?: string
 
   @IsString()
   @IsOptional()
-  readonly classHours: string
+  readonly classHours?: string
 
   @MaxLength(64)
   @IsString()
   @IsOptional()
-  readonly email: string
+  readonly email?: string
 
   @IsArray()
   @IsOptional()
-  readonly courseList: SyllabusCourse[]
+  readonly courseList?: SyllabusCourse[]
 
   @IsArray()
   @IsOptional()

--- a/server/modules/syllabus/domain/syllabus.ts
+++ b/server/modules/syllabus/domain/syllabus.ts
@@ -5,12 +5,12 @@ export interface Syllabus {
     id?: string,
     name: string,
     instructor: string,
-    location: string,
+    location?: string,
     institution?: string,
-    officeHours: string,
-    classHours: string,
-    email: string,
-    courseList: SyllabusCourse[]
+    officeHours?: string,
+    classHours?: string,
+    email?: string,
+    courseList?: SyllabusCourse[]
     code?: SyllabusCode,
     ownerList: string[],
 }


### PR DESCRIPTION
## Changes

From #855 we decided to left only as required specifically the params `name` and `instructor`.

## Implementation details

All the _Syllabus_ parameters excepted `name` and `instructor` are configured as **optional**.