### PR TITLE
Check input pristine status

### DIFF
--- a/frontend/vue/components/Syllabus/SyllabusFormCourseInfo.vue
+++ b/frontend/vue/components/Syllabus/SyllabusFormCourseInfo.vue
@@ -126,13 +126,33 @@ export default defineComponent({
         label: 'Save to syllabus',
         url: '#'
       },
-      syllabusSaved: false
+      syllabusSaved: false,
+      nameInputIsPristine: true,
+      instructorIsPristine: true
     }
   },
   methods: {
+    isPristine () {
+      if (this.nameInputIsPristine) {
+        this.nameInputIsPristine = (this.$refs.nameInput as BXInput).value.length === 0
+      }
+      if (this.instructorIsPristine) {
+        this.instructorIsPristine = (this.$refs.instructorInput as BXInput).value.length === 0
+      }
+    },
     isValid () {
-      const hasName = (this.$refs.nameInput as BXInput).checkValidity()
-      const hasInstructor = (this.$refs.instructorInput as BXInput).checkValidity()
+      let hasName = false
+      let hasInstructor = false
+
+      this.isPristine()
+
+      if (!this.nameInputIsPristine) {
+        hasName = (this.$refs.nameInput as BXInput).checkValidity()
+      }
+      if (!this.instructorIsPristine) {
+        hasInstructor = (this.$refs.instructorInput as BXInput).checkValidity()
+      }
+
       return hasName && hasInstructor
     },
     saveInfoAction () {


### PR DESCRIPTION
## Changes

From #928 this PR improves the UX to just validate those inputs that went modified before show an error.

## How to read this PR

- modify `name` or `instructor` and check if the validations show an error in other inputs that were not modified.

## Screenshots

<img width="685" alt="Screenshot 2022-04-22 at 12 26 18" src="https://user-images.githubusercontent.com/9059044/164692545-b118fdff-393c-45b5-869d-0a4930b4a2ab.png">

How the user didn't reach to the instructor field that input is `pristine` and is not validated.