### PR TITLE
build error with `simple-git-hooks`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,9 @@ jobs:
           node-version: "16"
           cache: "npm"
 
+      # overwrite "prepare" script in deployment since git hooks are not needed
+      - run: npm set-script prepare ""
+
       - run: npm ci
 
       - name: Install Python 3.8

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "patch": "patch-package",
     "postbuild:studio": "ts-node -s converter/postbuild.ts",
     "postinstall": "patch-package",
-    "prepare": "npx simple-git-hooks",
+    "prepare": "simple-git-hooks",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test": "start-server-and-test start :8080/health cy:run",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "patch": "patch-package",
     "postbuild:studio": "ts-node -s converter/postbuild.ts",
     "postinstall": "patch-package",
-    "prepare": "simple-git-hooks",
+    "prepare": "npx simple-git-hooks",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
     "test": "start-server-and-test start :8080/health cy:run",


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/951

disable setting up git hooks when deployment. it is not needed and is causing build failures.

## Implementation details

overwrite the `prepare` script in `package.json` before running `npm ci` so git hooks setup is not attempted

## How to read this PR

1. review update to `release.yml`
2. see previously failed build due to `simple-git-hooks`: https://github.com/Qiskit/platypus/runs/6190013441?check_suite_focus=true
3. see successful build after removing `simple-git-hooks` setup: https://github.com/Qiskit/platypus/runs/6222812881?check_suite_focus=true


