### PR TITLE
Fixed typo of Rz

### DIFF
--- a/notebooks/ch-states/single-qubit-gates.ipynb
+++ b/notebooks/ch-states/single-qubit-gates.ipynb
@@ -465,7 +465,7 @@
     "The $R_\\phi$-gate is _parameterized,_ that is, it needs a number ($\\phi$) to tell it exactly what to do. The $R_\\phi$-gate performs a rotation of $\\phi$ around the Z-axis direction (and as such is sometimes also known as the $R_z$-gate). It has the matrix:\n",
     "\n",
     "$$\n",
-    "R_\\phi = \\begin{bmatrix} e^{-i\\phi} & 0 \\\\ 0 & e^{i\\phi} \\end{bmatrix}\n",
+    "R_\\phi = \\begin{bmatrix} e^{-i\\phi/2} & 0 \\\\ 0 & e^{i\\phi/2} \\end{bmatrix}\n",
     "$$\n",
     "\n",
     "Where $\\phi$ is a real number.\n",

--- a/notebooks/ch-states/single-qubit-gates.ipynb
+++ b/notebooks/ch-states/single-qubit-gates.ipynb
@@ -465,7 +465,7 @@
     "The $R_\\phi$-gate is _parameterized,_ that is, it needs a number ($\\phi$) to tell it exactly what to do. The $R_\\phi$-gate performs a rotation of $\\phi$ around the Z-axis direction (and as such is sometimes also known as the $R_z$-gate). It has the matrix:\n",
     "\n",
     "$$\n",
-    "R_\\phi = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i\\phi} \\end{bmatrix}\n",
+    "R_\\phi = \\begin{bmatrix} e^{-i\\phi} & 0 \\\\ 0 & e^{i\\phi} \\end{bmatrix}\n",
     "$$\n",
     "\n",
     "Where $\\phi$ is a real number.\n",


### PR DESCRIPTION
Fixed typo of Rz "R_\\phi = \\begin{bmatrix} 1 & 0 \\\\ 0 & e^{i\\phi} \\end{bmatrix}\n"
It should be "R_\\phi = \\begin{bmatrix} e^{-i\\phi} & 0 \\\\ 0 & e^{i\\phi} \\end{bmatrix}\n"

ref: https://qiskit.org/documentation/stubs/qiskit.circuit.library.RZGate.html

authored-by: @ChihHanHuang

## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
