### PR TITLE
Added redirectTo property to the SessionData

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "watch:studio": "mgon-build --assets --watch",
     "watch": "npm-run-all --parallel watch:vue watch:studio",
     "start": "ts-node --transpile-only -I public -P server/tsconfig.json server/app.ts",
-    "start-dev": "nodemon --watch 'server/**/*.ts' --exec 'ts-node -I public -P server/tsconfig.json server/app.ts'",
+    "start-dev": "nodemon --watch 'server/**/*.ts' --exec 'ts-node --files -I public -P server/tsconfig.json server/app.ts'",
     "dev": "npm-run-all --parallel watch start-dev",
     "thumbnails": "mgon-build --thumbnails",
     "screenshots": "mgon-screenshots --output screenshots",

--- a/server/app.ts
+++ b/server/app.ts
@@ -83,11 +83,8 @@ const getUserProgressData = async (req: Request) => {
 }
 
 const getAccountData = async (req: Request, res: Response) => {
-  // @ts-ignore
   if (req.session.redirectTo) {
-    // @ts-ignore
     const syllabusRedirectUrl = req.session.redirectTo
-    // @ts-ignore
     delete req.session.redirectTo
     return res.redirect(syllabusRedirectUrl)
   }
@@ -170,7 +167,7 @@ const start = () => {
       req.user.oAuthTokens = [
         `qiskit:${randomString}`
       ]
-      // @ts-ignore
+
       delete req.session.redirectTo
 
       try {
@@ -236,7 +233,6 @@ const start = () => {
     .get('/signin', (req, res) => {
       const syllabusRedirect = req.query.returnTo
       if (syllabusRedirect) {
-        // @ts-ignore
         req.session.redirectTo = String(syllabusRedirect)
       }
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,3 +1,4 @@
 {
-  "extends": "../node_modules/@mathigon/studio/server/tsconfig.json"
+  "extends": "../node_modules/@mathigon/studio/server/tsconfig.json",
+  "include": ["./types"]
 }

--- a/server/types/express-session/index.d.ts
+++ b/server/types/express-session/index.d.ts
@@ -1,0 +1,7 @@
+export {}
+
+declare module 'express-session' {
+  interface SessionData {
+    redirectTo: string
+  }
+}


### PR DESCRIPTION
## Changes

From #948 

## Implementation details

- Created a new `d.ts` file for `express-session` module that extends the current `SessionData`.
- Configured the `tsconfig` to include this file
- Added `--files` option in **ts-node**. I would like to give more context here because the investigation was a bit difficult:
  - [Issue](https://github.com/TypeStrong/ts-node/issues/782) about including custom types in **ts-node**
  - [Documentation](https://github.com/TypeStrong/ts-node#help-my-types-are-missing) from **ts-node**
  - Seems that ts-node is having a hard time handling custom types from users. Initially they have a documentation where they explain a configuration step by step but as you can read in the issue it gives more headaches than solutions (I couldn't it make it work either). So I opted for the `--files` option that enables the standard **tsc** behaviour and takes into account the `includes` folder. This way I could make it work.
- I only added the `--files` option in the development command because is where we check the types.

## How to read this PR

- Added support for types extension: **express-session** in this case.
- Removed the unneeded `ts-ignore`
