### PR TITLE
Setup NODE_ENV

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -17,3 +17,6 @@ liveness_check:
 
 readiness_check:
   path: "/health"
+
+env_variables:
+  NODE_ENV: "production"


### PR DESCRIPTION
## Changes

Fix #975 

## Implementation details

I just followed the steps described in [App Engine documentation](https://cloud.google.com/appengine/docs/standard/nodejs/config/appref#environment_variables).

It seems very simple but how at the end of the day we only use App Engine in production, this should be more than enough.

## How to read this PR

I just added the `env_variables` property to the `app.yaml` and this should be more than enough to configure the environment. We can check this functionality with #965 .
