### PR TITLE
Fixed typo in barren plateaus

### DIFF
--- a/notebooks/quantum-machine-learning/training.ipynb
+++ b/notebooks/quantum-machine-learning/training.ipynb
@@ -989,7 +989,7 @@
     "\n",
     "### Exponentially vanishing gradients (barren plateaus)\n",
     "\n",
-    "Let's pick a standard parameterized quantum circuit ([`RealAmplitudes`](https://qiskit.org/documentation/stubs/qiskit.circuit.library.RealAmplitudes.html)) and see what happens if we increase the number of qubits and layers, that is increase the width and depth of thee circuit) as we calculate the gradient.\n",
+    "Let's pick a standard parameterized quantum circuit ([`RealAmplitudes`](https://qiskit.org/documentation/stubs/qiskit.circuit.library.RealAmplitudes.html)) and see what happens if we increase the number of qubits and layers, that is increase the width and depth of the circuit) as we calculate the gradient.\n",
     "\n",
     "![Image of an 'n' qubit quantum cirucit. An RY(theta_n) acts on each qubit, followed by some CNOTs and more RY gates (with different parameters). The CNOTs and other RY gates are repeated 'n' times.](images/training/bpcircuit.svg)"
    ]


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->
Fixed typo of 'thee' to 'the'.
