### PR TITLE
Fix latex in headers

### DIFF
--- a/notebooks/ch-labs/Lab03_QuantumMeasurement.ipynb
+++ b/notebooks/ch-labs/Lab03_QuantumMeasurement.ipynb
@@ -66,9 +66,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h3 style=\"font-size: 20px\">&#128211; 1. Express the expectation values of the Pauli operators for an arbitrary qubit state $|q\\rangle$ in the computational basis. </h3>\n",
+    "### &#128211; 1. Express the expectation values of the Pauli operators for an arbitrary qubit state $|q\\rangle$ in the computational basis.\n",
     "\n",
-    "The case for the expection value of Pauli Z gate is given as an example. "
+    "The case for the expectation value of Pauli Z gate is given as an example. "
    ]
   },
   {
@@ -95,14 +95,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h3 style=\"font-size: 20px\">2. Measure the Bloch sphere coordinates of a qubit using the qasm simulator and plot the vector on the bloch sphere.</h3>"
+    "### 2. Measure the Bloch sphere coordinates of a qubit using the qasm simulator and plot the vector on the bloch sphere."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">&#128211;Step A. Create a qubit state using the circuit method, <code>initialize</code> with two random complex numbers as the parameter.</h4>\n",
+    "#### &#128211;Step A. Create a qubit state using the circuit method, <code>initialize</code> with two random complex numbers as the parameter.\n",
     "\n",
     "To learn how to use the function `initialize`, check [here](https://qiskit.org/documentation/tutorials/circuits/3_summary_of_quantum_operations.html). ( go to the `arbitrary initialization` section. )"
    ]
@@ -124,7 +124,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">&#128211; Step B. Build the circuits to measure the expectation values of $X, Y, Z$ gate based on your answers to the question 1.  Run the cell below to estimate the bloch sphere coordinates of the qubit from step A using the qasm simulator.</h4>\n",
+    "#### &#128211; Step B. Build the circuits to measure the expectation values of $X, Y, Z$ gate based on your answers to the question 1.  Run the cell below to estimate the bloch sphere coordinates of the qubit from step A using the qasm simulator.\n",
     "\n",
     "The circuit for $Z$ gate measurement is given as an example."
    ]
@@ -258,7 +258,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h3 style=\"font-size: 20px\">&#128211; 1. Express the expectaion value of each term in the hamiltonian for an arbitrary two qubit state   $|\\psi \\rangle$ in the computational basis.</h3>\n",
+    "### &#128211; 1. Express the expectation value of each term in the hamiltonian for an arbitrary two qubit state   $|\\psi \\rangle$ in the computational basis.\n",
     "\n",
     "The case for the term $\\langle ZZ\\rangle$ is given as an example.\n",
     "\n",
@@ -283,7 +283,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">&#128211;Step A. Construct the circuits to prepare four different bell states.</h4>\n",
+    "#### &#128211;Step A. Construct the circuits to prepare four different bell states.\n",
     "\n",
     "Let's label each bell state as,\n",
     "$$\n",
@@ -342,7 +342,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">&#128211;Step B. Create the circuits to measure the expectation value of each term in the hamiltonian based on your answer to the question 1.</h4>"
+    "#### &#128211;Step B. Create the circuits to measure the expectation value of each term in the hamiltonian based on your answer to the question 1."
    ]
   },
   {
@@ -376,7 +376,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " <h4 style=\"font-size: 17px\">Step C. Execute the circuits on qasm simulator by runnng the cell below and evaluate the energy expectation value for each state.</h4>"
+    "#### Step C. Execute the circuits on qasm simulator by runnng the cell below and evaluate the energy expectation value for each state."
    ]
   },
   {
@@ -428,7 +428,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    " <h4 style=\"font-size: 17px\">Step D. Understanding the result. </h4>\n",
+    "#### Step D. Understanding the result.\n",
     "\n",
     "If you found the energy expectation values successfully, you would have obtained exactly the same value, $A (= 1.47e^{-6} eV)$, for the trplet tates, $|Tri1\\rangle, |Tri2\\rangle, |Tri3\\rangle$ and one lower energy level, $-3A (= -4.41e^{-6} eV)$ for the singlet state $|Sing\\rangle$.   \n",
     "\n",
@@ -488,7 +488,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">Step A. Run the following cells to load your account and select the backend </h4>"
+    "#### Step A. Run the following cells to load your account and select the backend"
    ]
   },
   {
@@ -521,7 +521,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">Step B. Execute the circuits on the quantum system. </h4>\n",
+    "#### Step B. Execute the circuits on the quantum system.\n",
     "\n",
     "\n",
     "In Lab1 when we excuted multiple circuits on a real quantum system, we submitted each circuit as a sperate job which produces the multiple job ids.  This time, we put all the circuits in a list and execute the list of the circuits as one job. In this way, all the circuit execution can happen at once, which would possibly decrease your wait time in the queue.\n",
@@ -622,7 +622,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">Step C. Estimate the ground state energy levels from the results of the previous step by executing the cells below. </h4>"
+    "#### Step C. Estimate the ground state energy levels from the results of the previous step by executing the cells below."
    ]
   },
   {
@@ -690,7 +690,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">Step D. Measurement error mitigation. </h4>\n",
+    "#### Step D. Measurement error mitigation.\n",
     "\n",
     "The results you obtained from running the circuits on the quantum system are not exact due to the noise from the various sources such as enery relaxation, dephasing, crosstalk between qubits, etc. In this step, we will alleviate the effects of the noise through the measurement error mitigation. Before we start, watch this [video](https://www.youtube.com/watch?v=yuDxHJOKsVA&list=PLOFEBzvs-Vvp2xg9-POLJhQwtVktlYGbY&index=8). "
    ]
@@ -789,7 +789,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<h4 style=\"font-size: 17px\">Step E. Interpret the result. </h4>"
+    "#### Step E. Interpret the result."
    ]
   },
   {


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/416


## Implementation details

- used Markdown syntax instead of HTML, in markdown cells
- this helped the latex render

## Notes
@frankharkins - I could use your guidance here. Please take a look at the video below. Notice that the headers are fixed when I change an `<h3>` to `###`... however, these items then get added to the side navigation. 

Is that something we want? Also, the numbering will need to be updated in the side nav.

All in all, it seems like the information hierarchy of this page, specifically, could use some guidance.

Your feedback is appreciated 🙏 

## Screenshots

https://user-images.githubusercontent.com/6276074/171299143-dd01c6db-940c-49d9-b486-17aea4673834.mov


