### PR TITLE
Fixed theta values for RY gate in Data Encoding Notebook (#993)

### DIFF
--- a/notebooks/quantum-machine-learning/encoding.ipynb
+++ b/notebooks/quantum-machine-learning/encoding.ipynb
@@ -301,8 +301,8 @@
     "qc = QuantumCircuit(3)\n",
     "\n",
     "qc.ry(0, 0)\n",
-    "qc.ry(math.pi/4, 1)\n",
-    "qc.ry(math.pi/2, 2)\n",
+    "qc.ry(2*math.pi/4, 1)\n",
+    "qc.ry(2*math.pi/2, 2)\n",
     "qc.draw()"
    ]
   },
@@ -558,7 +558,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -572,7 +572,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Changes

Changed the value of theta for RY gate from x to 2x as mentioned on issue #993. Data Encoding notebook in the Angled Encoding section.

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details
Added a 2* to the relevant code blocks

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

Check the code block at the end of the Data Enconding Notebook in the Anlged Encoding section

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots
<img width="281" alt="image" src="https://user-images.githubusercontent.com/6553024/172236405-31ba7041-4030-438c-b9e1-b81b6708655e.png">

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
