### PR TITLE
Add scratchpad to side panel

### DIFF
--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -6,15 +6,23 @@
     <p class="scratchpad__description">
       <strong>{{ $translate('Note') }}: </strong>{{ $translate('Code in the scratchpad will not be saved.') }}
     </p>
+    <CodeExercise :internal-code="initialCode" />
   </div>
 </template>
 
 <script lang="ts">
 import { Vue, Options } from 'vue-class-component'
+import CodeExercise from '../CodeExercise/CodeExercise.vue'
 
-@Options({})
+@Options({
+  components: {
+    CodeExercise
+  }
+})
 
-export default class Scratchpad extends Vue {}
+export default class Scratchpad extends Vue {
+  initialCode = 'test test this is initial code'
+}
 </script>
 
 <style scoped lang="scss">

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -54,7 +54,8 @@ export default class Scratchpad extends Vue {
   }
 
   run () {
-    // TODO
+    const codeOutput: any = this.$refs.output
+    codeOutput.requestExecute(this.code)
   }
 
   kernelRunning () {

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -6,22 +6,69 @@
     <p class="scratchpad__description">
       <strong>{{ $translate('Note') }}: </strong>{{ $translate('Code in the scratchpad will not be saved.') }}
     </p>
-    <CodeExercise :internal-code="initialCode" />
+    <div class="scratchpad__editor-block">
+      <CodeEditor
+        class="scratchpad__editor-block__editor"
+        :code="code"
+        :notebook-enabled="false"
+        @codeChanged="codeChanged"
+      />
+      <ExerciseActionsBar
+        class="scratchpad__editor-block__actions-bar"
+        :is-running="isKernelBusy"
+        :run-enabled="isKernelReady"
+        :grade-enabled="isKernelReady && isGradingExercise"
+        @run="run"
+      />
+    </div>
+    <CodeOutput
+      ref="output"
+      @running="kernelRunning"
+      @finished="kernelFinished"
+      @kernelReady="kernelReady"
+    />
   </div>
 </template>
 
 <script lang="ts">
 import { Vue, Options } from 'vue-class-component'
-import CodeExercise from '../CodeExercise/CodeExercise.vue'
+import CodeEditor from '../CodeExercise/CodeEditor.vue'
+import ExerciseActionsBar from '../CodeExercise/ExerciseActionsBar.vue'
+import CodeOutput from '../CodeExercise/CodeOutput.vue'
 
 @Options({
   components: {
-    CodeExercise
+    CodeEditor, ExerciseActionsBar, CodeOutput
   }
 })
 
 export default class Scratchpad extends Vue {
-  initialCode = 'test test this is initial code'
+  code = '\n \n \n \n \n \n \n \n \n '
+  isKernelBusy = false
+  isKernelReady = false
+  executedOnce = false
+  isGradingExercise = false
+
+  codeChanged (code: string) {
+    this.code = code
+  }
+
+  run () {
+    // TODO
+  }
+
+  kernelRunning () {
+    this.isKernelBusy = true
+    this.executedOnce = true
+  }
+
+  kernelFinished () {
+    this.isKernelBusy = false
+  }
+
+  kernelReady () {
+    this.isKernelReady = true
+  }
 }
 </script>
 
@@ -32,6 +79,10 @@ export default class Scratchpad extends Vue {
   &__description {
     @include type-style('body-short-01');
     margin-bottom: $spacing-05;
+  }
+
+  &__editor-block {
+    position: relative;
   }
 }
 </style>

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -43,10 +43,9 @@ import CodeOutput from '../CodeExercise/CodeOutput.vue'
 })
 
 export default class Scratchpad extends Vue {
-  code = '\n \n \n \n \n \n \n \n \n '
+  code = '\n \n \n'
   isKernelBusy = false
   isKernelReady = false
-  executedOnce = false
   isGradingExercise = false
 
   codeChanged (code: string) {
@@ -60,7 +59,6 @@ export default class Scratchpad extends Vue {
 
   kernelRunning () {
     this.isKernelBusy = true
-    this.executedOnce = true
   }
 
   kernelFinished () {
@@ -84,6 +82,12 @@ export default class Scratchpad extends Vue {
 
   &__editor-block {
     position: relative;
+    &__actions-bar {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      z-index: 3;
+    }
   }
 }
 </style>


### PR DESCRIPTION
## Changes

Closes #1059 

## Implementation details

- added `CodeEditor`, `ExerciseActionsBar`, and `CodeOutput` to sidepanel
- added `run()` functionality (based off `CodeExercise` implemenation)

## Screenshots



https://user-images.githubusercontent.com/6276074/173878383-a0a632c6-9857-49f9-8254-394ad73b6f82.mov



