### PR TITLE
Increase default space size for release gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     name: Build, Test, and Release
 
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Changes

From #967 we needed to increase the default size for the tests and it seems that [the error size](https://github.com/Qiskit/platypus/runs/6920018084?check_suite_focus=true#step:11:688) that we are having in the release gh-action it's related with the same cause.

I moved the change applied by Va in `test.yml` to `release.yml`. Let's see if with that we solve the problem.