### PR TITLE
Update attribute typo and `alignment` value

### DIFF
--- a/frontend/vue/components/CodeExercise/CodeEditorTools.vue
+++ b/frontend/vue/components/CodeExercise/CodeEditorTools.vue
@@ -3,7 +3,7 @@
     <div v-if="resetEnabled" class="code-editors-tools__button">
       <bx-tooltip-icon
         class="code-editors-tools__button__tooltip"
-        aligment="center"
+        alignment="end"
         direction="top"
         :body-text="$translate('Reset cell to initial content')"
         @click="reset"
@@ -14,7 +14,7 @@
     <div v-if="scratchpadEnabled" class="code-editors-tools__button">
       <bx-tooltip-icon
         class="code-editors-tools__button__tooltip"
-        aligment="center"
+        alignment="end"
         direction="top"
         :body-text="$translate('Copy to scratchpad')"
         @click="scratchpad"


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/1214

## Implementation details

- corrected spelling of `alignment` attribute/property
- updated alignment value to fix Scratchpad panel overflow issue

## Screenshots of before/after

https://user-images.githubusercontent.com/6276074/175141475-f04cacc6-142e-4b00-8e09-3729001db955.mov


