### PR TITLE
Fixed typo of half adder

### DIFF
--- a/notebooks/ch-states/atoms-computation.ipynb
+++ b/notebooks/ch-states/atoms-computation.ipynb
@@ -566,9 +566,7 @@
     }
    },
    "source": [
-    "The two bits we want to add are encoded in the qubits 0 and 1. The above example encodes a ```1``` in both these qubits, and so it seeks to find the solution of ```1+1```. The result will be a string of two bits, which we will read out from the qubits 2 and 3 and store in classical bits 0 and 1, respectively. All that remains is to fill in the actual program, which lives in the blank space in the middle.\n",
-    "\n",
-    "The dashed lines in the image are just to distinguish the different parts of the circuit (although they can have more interesting uses too). They are made by using the `barrier` command.\n",
+    "The two bits we want to add are encoded in the qubits 0 and 1. The above example encodes a ```1``` in both these qubits, and so it seeks to find the solution of ```1+1```. The result will be a string of two bits, which we will read out from the qubits 2 and 3 and store in classical bits 0 and 1, respectively.\n",
     "\n",
     "The basic operations of computing are known as logic gates. We’ve already used the NOT gate, but this is not enough to make our half adder. We could only use it to manually write out the answers. Since we want the computer to do the actual computing for us, we’ll need some more powerful gates.\n",
     "\n",


### PR DESCRIPTION
The figure is as the following
![image](https://user-images.githubusercontent.com/52871925/175557392-3ad505de-ab9e-4e74-b341-905a0a1ea585.png)

The Figure is without dashed lines (barrier) and filled with the actual program comparing with the old textbook (https://qiskit.org/textbook/ch-states/atoms-computation.html)

This fix deletes redundant texts to fit the figure:
All that remains is to fill in the actual program, which lives in the blank space in the middle.

The dashed lines in the image are just to distinguish the different parts of the circuit (although they can have more interesting uses too). They are made by using the barrier command.

## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
