### PR TITLE
Small mistake in the code for the VQE notebook update in PR #1188

### DIFF
--- a/notebooks/ch-applications/vqe-molecules.ipynb
+++ b/notebooks/ch-applications/vqe-molecules.ipynb
@@ -610,7 +610,7 @@
    "source": [
     "molecule = Molecule(\n",
     "    geometry=[[\"H\", [0.0, 0.0, -0.3625]],\n",
-    "              [\"H\", [dist, 0.0, 0.3625]]],\n",
+    "              [\"H\", [0.0, 0.0, 0.3625]]],\n",
     "    multiplicity=1,charge=0)\n",
     "\n",
     "driver = ElectronicStructureMoleculeDriver(\n",


### PR DESCRIPTION
## Changes
Just fixed a small mistake when defining the distances for the H2 molecule in the last section of the notebook. Sorry I didn't catch it before the merge.
<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
