### PR TITLE
Fix text in SVG code output

### DIFF
--- a/frontend/scss/components/textbook__page.scss
+++ b/frontend/scss/components/textbook__page.scss
@@ -110,3 +110,15 @@ main.body {
     }
   }
 }
+
+// Fix text in code output SVGs
+circle,
+g,
+image,
+line,
+path,
+polyline,
+use {
+  transform-box: inherit;
+  transform-origin: revert;
+}


### PR DESCRIPTION
## Changes

Fixes #1041.

Not 100% sure what's going on here, but looks like 9fd4328106238a9d0d3e2a72f5173238b6ff1843 broke text in SVG code outputs (previously fixed in https://github.com/Qiskit/platypus/pull/16). This PR pulls in some of the css from https://github.com/Qiskit/platypus/pull/16, which seems to fix the problem again (though for some reason it only seems to work if I remove the outer selectors, so code is not identical to that in #16 and so will need looking at carefully).

## Screenshots

<a href="https://learn.qiskit.org/course/ch-algorithms/quantum-phase-estimation#getting_more_precision" target="_blank">
<img width="718" alt="Screenshot 2022-06-28 at 12 57 31" src="https://user-images.githubusercontent.com/36071638/176172855-55f076b8-f894-4e84-bc07-9481797adaae.png"> </a>

<a href="https://platypus-pr-1236.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/ch-algorithms/quantum-phase-estimation#getting_more_precision" target="_blank">
<img width="718" alt="Screenshot 2022-06-28 at 12 58 50" src="https://user-images.githubusercontent.com/36071638/176173124-b08aaf51-ca39-4369-8130-a306d1a59868.png">
</a>
