### PR TITLE
Scratchpad: reset code output

### DIFF
--- a/frontend/vue/components/CodeExercise/CodeEditor.vue
+++ b/frontend/vue/components/CodeExercise/CodeEditor.vue
@@ -95,6 +95,7 @@ export default defineComponent({
       this.resetNotificationOpen = false
       this.internalCode = this.initialCode
       this.$emit('codeChanged', this.internalCode)
+      this.$emit('resetOutput');
     },
     codeChanged (code: string) {
       this.internalCode = code

--- a/frontend/vue/components/CodeExercise/CodeOutput.vue
+++ b/frontend/vue/components/CodeExercise/CodeOutput.vue
@@ -47,12 +47,16 @@ export default defineComponent({
   methods: {
     requestExecute (code: string) {
       this.error = ''
+      this.outputArea!.setHidden(true)
       this.kernelPromise!.then((kernel: IKernelConnection) => {
         this.$emit('running')
         try {
           const requestFuture = kernel.requestExecute({ code })
           this.setOutputFuture(requestFuture)
-          requestFuture.done.then(() => this.$emit('finished'))
+          requestFuture.done.then(() => {
+            this.$emit('finished')
+            this.outputArea!.setHidden(false)
+          })
           requestFuture.registerMessageHook((msgContainer) => {
             const message = (msgContainer as IStreamMsg)?.content?.text
             if (message && message.includes("Your answer is correct")) {
@@ -62,12 +66,15 @@ export default defineComponent({
           })
         } catch (error: any) {
           this.error = error as string
-          this.outputArea!.model.clear()
+          this.outputArea!.setHidden(false)
         }
       })
     },
     setOutputFuture (future : IOutputShellFuture) {
       this.outputArea!.future = future
+    },
+    clearOutput () {
+      this.outputArea!.setHidden(true)
     }
   }
 })

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -81,7 +81,7 @@ export default class Scratchpad extends Vue {
 
   resetOutput () {
     const codeOutput: any = this.$refs.output
-    codeOutput.requestExecute(this.code)
+    codeOutput.clearOutput()
   }
 
   run () {

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -13,6 +13,7 @@
         :initial-code="initialCode"
         :scratchpad-enabled="false"
         @codeChanged="codeChanged"
+        @resetOutput="resetOutput"
       />
       <ExerciseActionsBar
         class="scratchpad__editor-block__actions-bar"
@@ -76,6 +77,11 @@ export default class Scratchpad extends Vue {
 
   codeChanged (code: string) {
     this.code = code
+  }
+
+  resetOutput () {
+    const codeOutput: any = this.$refs.output
+    codeOutput.requestExecute(this.code)
   }
 
   run () {


### PR DESCRIPTION
## Changes

Fixes #1234 

## Implementation details

Emit `resetOutput` when user confirms reset

## Screenshots

https://user-images.githubusercontent.com/6276074/176257941-c2c31978-cf9c-4652-849c-918f4797690b.mov


