### PR TITLE
Fix qiskit to 0.36

### DIFF
--- a/converter/textbook-converter/requirements-test.txt
+++ b/converter/textbook-converter/requirements-test.txt
@@ -1,7 +1,7 @@
 nbqa
 pylint
 scour
-qiskit
+qiskit==0.36
 qiskit-nature
 matplotlib
 mypy


### PR DESCRIPTION
## Changes

Qiskit 0.37 was released yesterday and has a few breaking changes. I will work on updating the notebooks, but for now fix the version to 0.36 so the checks can pass.
