### PR TITLE
Update Qiskit to 0.37

### DIFF
--- a/converter/textbook-converter/requirements-test.txt
+++ b/converter/textbook-converter/requirements-test.txt
@@ -1,7 +1,7 @@
 nbqa
 pylint
 scour
-qiskit
+qiskit==0.36
 qiskit-nature
 matplotlib
 mypy

--- a/notebooks/ch-appendix/qiskit.ipynb
+++ b/notebooks/ch-appendix/qiskit.ipynb
@@ -1040,7 +1040,7 @@
    },
    "outputs": [],
    "source": [
-    "from qiskit.test.mock import FakeAthens\n",
+    "from qiskit.providers.fake_provider import FakeAthens\n",
     "athens = FakeAthens()"
    ]
   },

--- a/notebooks/ch-applications/image-processing-frqi-neqr.ipynb
+++ b/notebooks/ch-applications/image-processing-frqi-neqr.ipynb
@@ -631,7 +631,7 @@
     }
    ],
    "source": [
-    "from qiskit.test.mock import FakeAthens\n",
+    "from qiskit.providers.fake_provider import FakeAthens\n",
     "fake_athens = FakeAthens()\n",
     "# The device coupling map is needed for transpiling to correct\n",
     "# CNOT gates before simulation\n",

--- a/notebooks/ch-applications/satisfiability-grover.ipynb
+++ b/notebooks/ch-applications/satisfiability-grover.ipynb
@@ -371,7 +371,7 @@
    "outputs": [],
    "source": [
     "# Load our saved IBMQ accounts and get the ibmq_16_melbourne backend\n",
-    "from qiskit.test.mock import FakeMelbourne\n",
+    "from qiskit.providers.fake_provider import FakeMelbourne\n",
     "melbourne = FakeMelbourne()"
    ]
   },

--- a/notebooks/ch-applications/vqe-molecules.ipynb
+++ b/notebooks/ch-applications/vqe-molecules.ipynb
@@ -155,7 +155,7 @@
     "\n",
     "We will now use the simple single qubit variational form to solve a problem similar to ground state energy estimation. Specifically, we are given a random probability vector $\\vec{x}$ and wish to determine a possible parameterization for our single qubit variational form such that it outputs a probability distribution that is close to $\\vec{x}$ (where closeness is defined in terms of the Manhattan distance between the two probability vectors).\n",
     "\n",
-    "We first create the random probability vector in python:"
+    "We first create the random probability distribution in Python:"
    ]
   },
   {
@@ -167,9 +167,8 @@
     "# pylint: disable=missing-function-docstring\n",
     "import numpy as np\n",
     "np.random.seed(999999)\n",
-    "target_distr = np.random.rand(2)\n",
-    "# We now convert the random vector into a valid probability vector\n",
-    "target_distr /= sum(target_distr)"
+    "p0 = np.random.random()\n",
+    "target_distr = {0: p0, 1: 1-p0}"
    ]
   },
   {
@@ -208,31 +207,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit import Aer, transpile, assemble\n",
-    "backend = Aer.get_backend(\"qasm_simulator\")\n",
-    "NUM_SHOTS = 10000\n",
+    "from qiskit import Aer\n",
+    "backend = Aer.get_backend(\"aer_simulator\")\n",
     "\n",
-    "def get_probability_distribution(counts):\n",
-    "    output_distr = [v / NUM_SHOTS for v in counts.values()]\n",
-    "    if len(output_distr) == 1:\n",
-    "        output_distr.append(1 - output_distr[0])\n",
-    "    return output_distr\n",
+    "def counts_to_distr(counts):\n",
+    "    \"\"\"Convert Qiskit result counts to dict with integers as\n",
+    "    keys, and pseudo-probabilities as values.\"\"\"\n",
+    "    n_shots = sum(counts.values())\n",
+    "    return {int(k, 2): v/n_shots for k, v in counts.items()}\n",
     "\n",
     "def objective_function(params):\n",
-    "    # Obtain a quantum circuit instance from the paramters\n",
+    "    \"\"\"Compares the output distribution of our circuit with\n",
+    "    parameters `params` to the target distribution.\"\"\"\n",
+    "    # Create circuit instance with paramters and simulate it\n",
     "    qc = get_var_form(params)\n",
-    "    # Execute the quantum circuit to obtain the probability\n",
-    "    # distribution associated with the current parameters\n",
-    "    t_qc = transpile(qc, backend)\n",
-    "    qobj = assemble(t_qc, shots=NUM_SHOTS)\n",
-    "    result = backend.run(qobj).result()\n",
-    "    # Obtain the counts for each measured state, and convert\n",
-    "    # those counts into a probability vector\n",
-    "    output_distr = get_probability_distribution(result.get_counts(qc))\n",
+    "    result = backend.run(qc).result()\n",
+    "    # Get the counts for each measured state, and convert\n",
+    "    # those counts into a probability dict\n",
+    "    output_distr = counts_to_distr(result.get_counts())\n",
     "    # Calculate the cost as the distance between the output\n",
     "    # distribution and the target distribution\n",
     "    cost = sum(\n",
-    "        np.abs(output_distr[i] - target_distr[i]) for i in range(2))\n",
+    "        abs(target_distr.get(i, 0) - output_distr.get(i, 0))\n",
+    "        for i in range(2**qc.num_qubits)\n",
+    "    )\n",
     "    return cost"
    ]
   },
@@ -240,7 +238,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, we create an instance of the COBYLA optimizer, and run the algorithm. Note that the output varies from run to run. Moreover, while close, the obtained distribution might not be exactly the same as the target distribution, however, increasing the number of shots taken will increase the accuracy of the output."
+    "Finally, we create an instance of the COBYLA optimizer, and run the algorithm. Note that the output varies from run to run due to random noise. Moreover, while close, the obtained distribution will not be exactly the same as the target distribution."
    ]
   },
   {
@@ -252,38 +250,33 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Target Distribution: [0.51357006 0.48642994]\n",
-      "Obtained Distribution: [0.5168, 0.4832]\n",
-      "Output Error (Manhattan Distance): 0.003140118738839126\n",
-      "Parameters Found: [1.55029302 0.76612133 0.64945506]\n"
+      "Parameters Found: [ 2.01069788  2.13944812 -0.34546855]\n",
+      "Target Distribution: {0: 0.308979188922057, 1: 0.691020811077943}\n",
+      "Obtained Distribution: {0: 0.2842, 1: 0.7158}\n",
+      "Cost: 0.004677127844114004\n"
      ]
     }
    ],
    "source": [
     "from qiskit.algorithms.optimizers import COBYLA\n",
-    "\n",
-    "# Initialize the COBYLA optimizer\n",
     "optimizer = COBYLA(maxiter=500, tol=0.0001)\n",
     "\n",
     "# Create the initial parameters (noting that our\n",
     "# single qubit variational form has 3 parameters)\n",
     "params = np.random.rand(3)\n",
-    "ret = optimizer.optimize(\n",
-    "    num_vars=3,\n",
-    "    objective_function=objective_function,\n",
-    "    initial_point=params)\n",
+    "result = optimizer.minimize(\n",
+    "    fun=objective_function,\n",
+    "    x0=params)\n",
     "\n",
     "# Obtain the output distribution using the final parameters\n",
-    "qc = get_var_form(ret[0])\n",
-    "t_qc = transpile(qc, backend)\n",
-    "qobj = assemble(t_qc, shots=NUM_SHOTS)\n",
-    "counts = backend.run(qobj).result().get_counts(qc)\n",
-    "output_distr = get_probability_distribution(counts)\n",
+    "qc = get_var_form(result.x)\n",
+    "counts = backend.run(qc, shots=10000).result().get_counts()\n",
+    "output_distr = counts_to_distr(counts)\n",
     "\n",
+    "print(\"Parameters Found:\", result.x)\n",
     "print(\"Target Distribution:\", target_distr)\n",
     "print(\"Obtained Distribution:\", output_distr)\n",
-    "print(\"Output Error (Manhattan Distance):\", ret[1])\n",
-    "print(\"Parameters Found:\", ret[0])"
+    "print(\"Cost:\", objective_function(result.x))"
    ]
   },
   {
@@ -653,7 +646,7 @@
    },
    "outputs": [],
    "source": [
-    "from qiskit.test.mock import FakeManila\n",
+    "from qiskit.providers.fake_provider import FakeManila\n",
     "from qiskit.providers.aer import QasmSimulator\n",
     "\n",
     "backend = Aer.get_backend('aer_simulator')\n",

--- a/notebooks/ch-labs/Lab06_IterativePhaseEstimation.ipynb
+++ b/notebooks/ch-labs/Lab06_IterativePhaseEstimation.ipynb
@@ -642,7 +642,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.test.mock import FakeAthens\n",
+    "from qiskit.providers.fake_provider import FakeAthens\n",
     "import qiskit.tools.jupyter\n",
     "\n",
     "backend = FakeAthens()\n",

--- a/notebooks/ch-labs/Lab07_Scalable_Shor_Algorithm.ipynb
+++ b/notebooks/ch-labs/Lab07_Scalable_Shor_Algorithm.ipynb
@@ -476,7 +476,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.test.mock import FakeMelbourne\n",
+    "from qiskit.providers.fake_provider import FakeMelbourne\n",
     "backend = FakeMelbourne()\n",
     "shots=8192"
    ]

--- a/notebooks/ch-quantum-hardware/hamiltonian-tomography.ipynb
+++ b/notebooks/ch-quantum-hardware/hamiltonian-tomography.ipynb
@@ -181,7 +181,7 @@
     "from qiskit.pulse import Play\n",
     "from qiskit.pulse.channels import ControlChannel, DriveChannel\n",
     "from qiskit.pulse.library import drag, GaussianSquare\n",
-    "from qiskit.test.mock import FakeAthens\n",
+    "from qiskit.providers.fake_provider import FakeAthens\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/notebooks/quantum-hardware/measuring-quantum-volume.ipynb
+++ b/notebooks/quantum-hardware/measuring-quantum-volume.ipynb
@@ -861,7 +861,7 @@
     }
    ],
    "source": [
-    "from qiskit.test.mock import FakeSantiago\n",
+    "from qiskit.providers.fake_provider import FakeSantiago\n",
     "santiago = FakeSantiago()\n",
     "test_qv(santiago, [0,1,2,3], ncircuits=150, nshots=50)"
    ]
@@ -987,7 +987,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.test.mock import FakeBoeblingen\n",
+    "from qiskit.providers.fake_provider import FakeBoeblingen\n",
     "boeblingen = FakeBoeblingen()"
    ]
   },

--- a/notebooks/quantum-machine-learning/qbm.ipynb
+++ b/notebooks/quantum-machine-learning/qbm.ipynb
@@ -900,7 +900,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qiskit.test.mock import FakeLima\n",
+    "from qiskit.providers.fake_provider import FakeLima\n",
     "backend = FakeLima()\n",
     "\n",
     "# Uncomment the code below to use the real device:\n",


### PR DESCRIPTION
## Changes

This PR updates the notebooks to work with 0.37.0.
- `qiskit.test.mock` is now deprecated
- `Optimizer.optimize` also deprecated

Also noticed a bug in the VQE page while changing to `minimize`; the old `get_probability_distribution` function assumed counts dicts were ordered by key when converting to array, which is often not true. I updated it to just stick with dicts throughout.
