### PR TITLE
Changing the figure order

### DIFF
--- a/notebooks/quantum-machine-learning/qgan.ipynb
+++ b/notebooks/quantum-machine-learning/qgan.ipynb
@@ -286,9 +286,9 @@
     "The objective with a fully quantum QGAN is for the quantum generator to reproduce a desired state $|\\psi\\rangle$, using of course an adversarial training strategy. Similar to other variational quantum algorithms, the quantum generator moves towards this through an iterative update to its parameters directed by a classical optimizer. However, in the case of a QGAN, the generator's cost function landscape itself evolves and becomes better as the discriminator improves at recognizing real samples. Let's look at the general circuit schematics of what we will be building.\n",
     "\n",
     "\n",
-    "![fake_rig](images/qgan/fake_rig.svg)\n",
-    "\n",
     "![real_rig](images/qgan/real_rig.svg)\n",
+    "\n",
+    "![fake_rig](images/qgan/fake_rig.svg)\n",
     "\n",
     "It is worth noting that although we only consider one register each for both the generator and discriminator, we could also add an [auxiliary](gloss:auxiliary) \"workspace\" register to both the generator and discriminator. "
    ]


### PR DESCRIPTION


## Changes
I changed a sentence of code to match the order of the figures between  "images/qgan/real_rig.svg" and "images/qgan/fake_rig.svg" with the text sentences " Looking at the first circuit diagram shows us how real data samples are fed into the discriminator" and "In the second circuit, a generated [wave function](gloss:wave-function) aimed to ...".

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->

## How to read this PR

<!--
  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->
