### PR TITLE
Fixes due to GitLocalize misinterpreting things

### DIFF
--- a/translations/es/ch-algorithms/bernstein-vazirani.ipynb
+++ b/translations/es/ch-algorithms/bernstein-vazirani.ipynb
@@ -34,7 +34,7 @@
         "\n",
         "En lugar de que la función sea balanceada o constante como en el problema de Deutsch-Jozsa, ahora se garantiza que la función devolverá el producto bit a bit de la entrada con alguna cadena, $s$. En otras palabras, dada una entrada $x$, $f(x) = s \\cdot x , \\text{(mod 2)}$. Estamos esperando encontrar $s$. Como circuito reversible clásico, el oráculo de Bernstein-Vazirani se ve así:\n",
         "\n",
-        "![circuito reversible clásico](https://github.com/Qiskit/platypus/blob/main/translations/es/ch-algorithms/images/bv2.png?raw=true)\n",
+        "![circuito reversible clásico](images/bv2.png)\n",
         "\n",
         "### 1.2 La Solución Clásica<a id=\"classical-solution\"> </a>\n",
         "\n",


### PR DESCRIPTION
## Changes

Fixes due to GitLocalize adding the full path of an image, when it should remain relative (as in the original file).
In file translations/es/ch-algorithms/bernstein-vazirani.ipynb

This PR must be merged before https://github.com/Qiskit/platypus/pull/1310

### Problems

- GitLocalize added the full path in a reference to an image, but in the original file this path is relative, also the path it added is left under the `translations/es` folder, where the images do not exist. See image 1.


## Screenshots

Image 1
<img src="https://user-images.githubusercontent.com/1554515/178118939-23b969a0-22b8-4c52-83ba-6064525faf2c.png" width="500">

