### PR TITLE
Instrument the copy to Scratchpad and Scratchpad reset actions

### DIFF
--- a/frontend/vue/components/CodeExercise/CodeExercise.vue
+++ b/frontend/vue/components/CodeExercise/CodeExercise.vue
@@ -122,6 +122,7 @@ export default defineComponent({
         detail: { code }
       })
 
+      window.textbook.trackClickEvent('Copy to Scratchpad', `Code cell #${this.id}, ${pageRoute}`)
       window.dispatchEvent(scratchpadCopyRequestEvent)
     },
     kernelRunning () {

--- a/frontend/vue/components/CodeExercise/CodeOutput.vue
+++ b/frontend/vue/components/CodeExercise/CodeOutput.vue
@@ -20,6 +20,14 @@ import { OutputArea, IOutputShellFuture, createOutputArea } from './OutputRender
 import { requestBinderKernel, IKernelConnection, IStreamMsg } from './KernelManager'
 import 'carbon-web-components/es/components/loading/loading'
 
+declare global {
+  interface Window {
+    textbook: any
+  }
+}
+
+const pageRoute = window.location.pathname
+
 export default defineComponent({
   name: 'CodeOutput',
   data () {
@@ -74,6 +82,7 @@ export default defineComponent({
       this.outputArea!.future = future
     },
     clearOutput () {
+      window.textbook.trackClickEvent('Reset', `Scratchpad code cell, ${pageRoute}`)
       this.outputArea!.setHidden(true)
     }
   }


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/1329

## Implementation details
- add segment info to instrument the `copy to Scratchpad` action
- add segment info to instrument the `Scratchpad reset` action

**Copy to Scratchpad**

https://user-images.githubusercontent.com/6276074/178346737-21e2587b-a8ae-41d2-b341-a16fc9c66c5d.mov




**Scratchpad reset**



https://user-images.githubusercontent.com/6276074/178346750-bc895d2f-be1e-4251-ba0c-134aaf7c85d6.mov


