### PR TITLE
Account url refactorization

### DIFF
--- a/frontend/vue/components/CodeExercise/CodeExercise.vue
+++ b/frontend/vue/components/CodeExercise/CodeExercise.vue
@@ -23,7 +23,7 @@
       <WarningIcon />
       <div>
         This code is using an IBMQ provider. If you want to execute it, you need to setup your API-token in
-        <BasicLink url="/account">
+        <BasicLink url="/account/admin">
           your account.
         </BasicLink>
       </div>

--- a/frontend/vue/components/Syllabus/SyllabusForm.vue
+++ b/frontend/vue/components/Syllabus/SyllabusForm.vue
@@ -86,7 +86,7 @@ export default defineComponent({
         url: '#'
       },
       cancelAction: {
-        url: '/account#Classroom',
+        url: '/account/classroom',
         label: this.$translate('Cancel'),
         segment: {
           cta: 'cancel',

--- a/frontend/vue/components/UserAccount/DeleteUserDataSection.vue
+++ b/frontend/vue/components/UserAccount/DeleteUserDataSection.vue
@@ -72,7 +72,7 @@ export default defineComponent({
         icon: 'delete-16',
         segment: {
           cta: 'delete-account',
-          location: 'user-account-privacy'
+          location: 'user-account-admin'
         }
       },
       modalSize: 'sm',

--- a/frontend/vue/components/constants/accountMenuLinks.ts
+++ b/frontend/vue/components/constants/accountMenuLinks.ts
@@ -1,7 +1,7 @@
 const ACCOUNT_MENU_LINKS = [
   {
     displayName: 'Learning',
-    url: '/account'
+    url: '/account/learning'
   },
   {
     displayName: 'Classroom',

--- a/frontend/vue/components/constants/accountMenuLinks.ts
+++ b/frontend/vue/components/constants/accountMenuLinks.ts
@@ -8,8 +8,8 @@ const ACCOUNT_MENU_LINKS = [
     url: '/account/classroom'
   },
   {
-    displayName: 'Privacy',
-    url: '/account/privacy'
+    displayName: 'Account',
+    url: '/account/admin'
   }
 ]
 

--- a/server/app.ts
+++ b/server/app.ts
@@ -187,7 +187,8 @@ const start = () => {
 
       res.redirect('/logout')
     })
-    .get('/account', getAccountData)
+    .get('/account', (req, res) => res.redirect('/account/learning'))
+    .get('/account/learning', getAccountData)
     .get('/account/classroom', getAccountData)
     .get('/account/admin', getAccountData)
     .get('/eula', (req, res) => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -189,7 +189,7 @@ const start = () => {
     })
     .get('/account', getAccountData)
     .get('/account/classroom', getAccountData)
-    .get('/account/privacy', getAccountData)
+    .get('/account/admin', getAccountData)
     .get('/eula', (req, res) => {
       if (!req.user) {
         return res.redirect('/signin')


### PR DESCRIPTION
## Changes

Related with #1199 
Co-authored by @techtolentino 


## Implementation details

- Changed `/account/privacy` to `/account/admin` (following a philosophy similar to GitHub: https://github.com/settings/admin)
- Changed `/account` to `/account/learning`
- Now `/account` redirects to `/account/learning`: this is interesting because if at some point we want to change the homepage for the account we only need to modify the redirection.
- Changed the references through the code.
- Fixed a little bug in a [classroom redirection](https://github.com/Qiskit/platypus/pull/1335/files#diff-0573c63df75100fb410d46ec23b5c4d9d7dc3c51b520485104b1dfa49597050bR89).

## How to read this PR

- Changed the URLs in the server and in the web
- Confirm that I didn't miss any of the URL's

