### PR TITLE
feat(analytics): instrument run on hardware CTA

### DIFF
--- a/frontend/vue/components/CodeExercise/CodeExercise.vue
+++ b/frontend/vue/components/CodeExercise/CodeExercise.vue
@@ -112,10 +112,11 @@ export default defineComponent({
     this.id = lastId++
   },
   methods: {
-    run () {
+    run (onHardware: boolean) {
       const codeOutput: any = this.$refs.output
       codeOutput.requestExecute(this.code)
-      window.textbook.trackClickEvent('Run', `Code cell #${this.id}, ${pageRoute}`)
+      const cta = onHardware ? 'Run (Hardware)' : 'Run'
+      window.textbook.trackClickEvent(cta, `Code cell #${this.id}, ${pageRoute}`)
     },
     grade () {
       const codeOutput: any = this.$refs.output

--- a/frontend/vue/components/CodeExercise/ExerciseActionsBar.vue
+++ b/frontend/vue/components/CodeExercise/ExerciseActionsBar.vue
@@ -3,7 +3,7 @@
     <button
       v-if="runEnabled && !isRunning && !isApiTokenNeeded"
       class="exercise-actions-bar__button exercise-actions-bar__button_run"
-      @click="run()"
+      @click="run(isApiTokenNeeded)"
     >
       {{ $translate('Run') }}
     </button>
@@ -53,9 +53,9 @@ export default defineComponent({
     }
   },
   methods: {
-    run () {
+    run (onHardware = false) {
       if (!this.isRunning) {
-        this.$emit('run')
+        this.$emit('run', onHardware)
       }
     },
     grade () {


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This PR send a click tracking event to Segment with the CTA parameter "Run (Hardware)" if the code cell ran on hardware. If it didn't ran on hardware, it'll continue to send only "Run".

Please @agebbie, help me confirm that this would be the desired result from your end as well, data-wise.

Closes #1337