### PR TITLE
scratchpad output styling

### DIFF
--- a/frontend/scss/vendor/thebelab.scss
+++ b/frontend/scss/vendor/thebelab.scss
@@ -117,7 +117,7 @@ div.jb_input div.input {
   font-size: 0.9em;
 }
 
-x-step {
+x-step, .code-output {
   .jp-OutputArea-output {
     pre {
       font-family: $plex-mono;


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/1378

make the content in scratchpad output area wrap so results can be viewed better


## Implementation details

the behavior of the output area in the scratchpad is made more consist with the output area of code blocks in main section. 
for the code blocks in the main section the output area is styled to wrap long content. the same styling has been applied to the scratchpad output area

## How to read this PR

- confirm css styles is correct and makes sense
- confirm scratchpad output area wraps long responses. see example code in https://github.com/Qiskit/platypus/issues/1378


## Screenshots

**before**

<img width="1490" alt="image" src="https://user-images.githubusercontent.com/13156555/181793773-87312e61-0605-465a-924a-bb7e921893b6.png">

**after**

<img width="1487" alt="image" src="https://user-images.githubusercontent.com/13156555/181793849-35745442-2844-4f43-b3aa-a967315868d7.png">

