### PR TITLE
add `is-api-token-needed` attribute

### DIFF
--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -20,6 +20,7 @@
         :is-running="isKernelBusy"
         :run-enabled="isKernelReady"
         :grade-enabled="isKernelReady && isGradingExercise"
+        :is-api-token-needed="isApiTokenNeeded"
         @run="run"
       />
     </div>
@@ -60,6 +61,7 @@ export default class Scratchpad extends Vue {
   isKernelBusy = false
   isKernelReady = false
   isGradingExercise = false
+  isApiTokenNeeded = false
 
   get initialCode () {
     return INITIAL_CODE


### PR DESCRIPTION
## Changes

pass the `is-api-token-needed` attribute from scratchpad to exercise action bar

## Implementation details

by default `is-api-token-needed` is true will disables run button. this PR update scratchpad component to set `is-api-token-needed` to false

this is an intermediate fix to re-enable the Run button. however, additional changes will be required to properly handle ardware execution in scratchpad

## How to read this PR

confirm scratchpad Run button is no longer disabled and code can be ran in the scratchpad

## Screenshots

<img width="656" alt="image" src="https://user-images.githubusercontent.com/13156555/182930050-5c0b1571-73d1-4170-ac0a-c60f2f939646.png">

