### PR TITLE
Make code cell outputs consistent

### DIFF
--- a/frontend/scss/vendor/thebelab.scss
+++ b/frontend/scss/vendor/thebelab.scss
@@ -114,29 +114,42 @@ div.jb_input div.input {
 
 .CodeMirror {
   font-family: $plex-mono;
-  font-size: 0.9em;
 }
 
 x-step, .code-output {
-  .jp-OutputArea-output {
     pre {
       font-family: $plex-mono;
       margin: 0;
       white-space: pre-wrap;
       word-wrap: break-word;
     }
-  }
 }
 
-div.jp-OutputArea-output {
+.code-exercise__editor-block, .scratchpad__editor-block{
+    border-bottom: 1px solid $border-color;
+    margin-bottom: -1px;  // To avoid double border when cell is running
+}
+
+.code-exercise {
+  border: 1px solid $border-color;
+  margin: $spacing-07 0;
+}
+
+.jp-OutputArea, .code-exercise__initial-code {
   padding: 18px;
+  padding-top: 19px;  // To account for negative margin in editor block
+  font-size: 12px;
 }
 
-div.jp-OutputArea > :first-child {
-  border-top: 1px solid $border-color !important;
+.code-exercise__initial-code__hidden-output, .jp-OutputArea:empty {
+  display: none;
 }
 
 .jp-OutputArea-child {
   background-color: $background-color-white;
-  padding: 18px;
+}
+
+.jp-OutputArea-prompt {
+  // Contains the cell execution no. (e.g. `[3]`)
+  display: none;
 }

--- a/frontend/vue/components/CodeExercise/CodeExercise.vue
+++ b/frontend/vue/components/CodeExercise/CodeExercise.vue
@@ -38,7 +38,7 @@
     />
     <div
       ref="initialCodeElement"
-      class="code-exercise__initial-code"
+      class="code-exercise__initial-code jp-OutputArea"
       :class="{'code-exercise__initial-code__hidden-output': executedOnce}"
     >
       <slot />

--- a/frontend/vue/components/CodeExercise/CodeExercise.vue
+++ b/frontend/vue/components/CodeExercise/CodeExercise.vue
@@ -39,7 +39,7 @@
     <div
       ref="initialCodeElement"
       class="code-exercise__initial-code jp-OutputArea"
-      :class="{'code-exercise__initial-code__hidden-output': executedOnce}"
+      :class="{'code-exercise__initial-code__hidden-output': hideInitialOutput}"
     >
       <slot />
     </div>
@@ -95,7 +95,7 @@ export default defineComponent({
       initialCode: '',
       isKernelBusy: false,
       isKernelReady: false,
-      executedOnce: false,
+      hideInitialOutput: false,
       isApiTokenNeeded: false,
       id: 0
     }
@@ -108,9 +108,13 @@ export default defineComponent({
   mounted () {
     const slotWrapper = (this.$refs.initialCodeElement as HTMLDivElement)
     const initialCodeElement = slotWrapper.getElementsByTagName('pre')[0]
+    const initialOutput = slotWrapper.getElementsByTagName('output')
     this.codeChanged(initialCodeElement?.textContent?.trim() ?? '')
     this.initialCode = this.code
     this.id = lastId++
+    if (initialOutput.length === 0) {
+      this.hideInitialOutput = true
+    }
   },
   methods: {
     run (onHardware: boolean) {
@@ -148,7 +152,7 @@ export default defineComponent({
     },
     kernelRunning () {
       this.isKernelBusy = true
-      this.executedOnce = true
+      this.hideInitialOutput = true
     },
     kernelFinished () {
       this.isKernelBusy = false

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -6,40 +6,42 @@
     <p class="scratchpad__description">
       <strong>{{ $translate('Note') }}: </strong>{{ $translate('Code in the scratchpad will not be saved.') }}
     </p>
-    <div class="scratchpad__editor-block">
-      <CodeEditor
-        class="scratchpad__editor-block__editor"
-        :code="code"
-        :initial-code="initialCode"
-        :scratchpad-enabled="false"
-        @codeChanged="codeChanged"
-        @resetOutput="resetOutput"
-      />
-      <ExerciseActionsBar
-        class="scratchpad__editor-block__actions-bar"
-        :is-running="isKernelBusy"
-        :run-enabled="isKernelReady"
-        :grade-enabled="isKernelReady && isGradingExercise"
-        :is-api-token-needed="isApiTokenNeeded"
-        @run="run"
-      />
-    </div>
-    <div v-if="isApiTokenNeeded" class="scratchpad__api-token-info">
-      <WarningIcon />
-      <div>
-        This code is executed on real hardware using an IBM Quantum provider. Setup your API-token in
-        <BasicLink url="/account/admin">
-          your account
-        </BasicLink>
-        to execute this code cell.
+    <div class="code-exercise">
+      <div class="scratchpad__editor-block">
+        <CodeEditor
+          class="scratchpad__editor-block__editor"
+          :code="code"
+          :initial-code="initialCode"
+          :scratchpad-enabled="false"
+          @codeChanged="codeChanged"
+          @resetOutput="resetOutput"
+        />
+        <ExerciseActionsBar
+          class="scratchpad__editor-block__actions-bar"
+          :is-running="isKernelBusy"
+          :run-enabled="isKernelReady"
+          :grade-enabled="isKernelReady && isGradingExercise"
+          :is-api-token-needed="isApiTokenNeeded"
+          @run="run"
+        />
       </div>
+      <div v-if="isApiTokenNeeded" class="scratchpad__api-token-info">
+        <WarningIcon />
+        <div>
+          This code is executed on real hardware using an IBM Quantum provider. Setup your API-token in
+          <BasicLink url="/account/admin">
+            your account
+          </BasicLink>
+          to execute this code cell.
+        </div>
+      </div>
+      <CodeOutput
+        ref="output"
+        @running="kernelRunning"
+        @finished="kernelFinished"
+        @kernelReady="kernelReady"
+      />
     </div>
-    <CodeOutput
-      ref="output"
-      @running="kernelRunning"
-      @finished="kernelFinished"
-      @kernelReady="kernelReady"
-    />
   </div>
 </template>
 


### PR DESCRIPTION
Currently, the code cell outputs are a much larger font to the editor code and the styling changes after a user runs a cell on the site. Binder also returns a cell execution count which we don't have a place for, and which we currently ignore in the pre-rendered outputs.

## Changes

- Make initial outputs and binder results use same styling
- Change font size to match editor fonts
- Fix small bug where border between editor and output disappears
- Fix small bug where scratchpad is missing border
- Hide Binder's cell execution count

## Screenshots

Before ([link](https://learn.qiskit.org/course/ch-prerequisites/introduction-to-python-and-jupyter-notebooks)):

https://user-images.githubusercontent.com/36071638/183388179-7e69f9b7-e960-462c-9586-cb04a330fbda.mov

After ([link](https://platypus-pr-1416.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/ch-prerequisites/introduction-to-python-and-jupyter-notebooks))

https://user-images.githubusercontent.com/36071638/183388155-c94ad345-738d-4971-96a7-29d9d8c1c37b.mov

## Remaining problems

- The outputs still don't match exactly as initial outputs seems to have an extra space before the text, and sometimes an extra newline after. If anyone knows how to fix this please let me know. I've played around with the converter but if I remove any more whitespace in the notebook to pug step then curly braces stop parsing correctly.