### PR TITLE
parse latex in code cell output

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -336,7 +336,7 @@ def handle_code_cell_output(cell_output):
         if "text/html" in cell_output["data"]:
             return "".join(cell_output["data"]["text/html"])
         if "text/latex" in cell_output["data"]:
-            return "".join(cell_output["data"]["text/latex"])
+            return "".join(cell_output["data"]["text/latex"]).strip().replace("$$", "")
         elif "text/plain" in cell_output["data"]:
             return f"pre \n{INDENT}| " + "".join(
                 cell_output["data"]["text/plain"]
@@ -408,9 +408,15 @@ def handle_code_cell(cell, resources):
     if include_output is not False and len(cell.outputs):
         code_lines.append(f'\n    output\n')
         for cell_output in cell.outputs:
+            is_latex = "data" in cell_output and "text/latex" in cell_output["data"]
             output = handle_code_cell_output(cell_output) or ""
             if output.startswith("pre"):
                 output = f"{INDENT * 2}" + output.replace("\n", f"\n{INDENT * 2}")
+                code_lines.append(f"{output}\n\n")
+            elif is_latex:
+                output = f"{INDENT * 2}div.md.\n{INDENT * 3}```latex\n{INDENT * 3}" + output.replace(
+                    "\n", f"\n{INDENT * 3}"
+                ).strip() + f"\n{INDENT * 3}```"
                 code_lines.append(f"{output}\n\n")
             elif len(output):
                 output = f"{INDENT * 2}div.\n{INDENT * 3}" + output.replace(


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/1243

updates parsing of `text/latex` data in cell output

preview: https://platypus-pr-1427.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/quantum-hardware/density-matrix

## Implementation details

cell output with `text/latex` data was not being handled accordingly by the converter and thus not being rendered/parsed properly. this  PR updates the converter to appropriately rewrite the latex output using syntax required by mathigon and pug. i.e.,

from (cell output syntax)

```
$$
|\psi_{AB}\rangle = 
\begin{bmatrix}
\tfrac{1}{\sqrt{2}} & 0 & 0 & \tfrac{1}{\sqrt{2}}  \\
 \end{bmatrix}
$$
```

to (mathigon/pug syntax)

```
div.md.
    ```latex
    |\psi_{AB}\rangle = 
    \begin{bmatrix}
    \tfrac{1}{\sqrt{2}} & 0 & 0 & \tfrac{1}{\sqrt{2}}  \\
    \end{bmatrix}
    ```
```


## How to read this PR

- review the converter code for rewriting latex output cell output
- from local deployment or [preview link](https://platypus-pr-1427.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/introduction/entangled-states#entangled-4-8) navigate to any page that has a code cell with latex output and confirm the output is rendered as expected, e.g.,
    - `/course/introduction/entangled-states#entangled-4-8`
    - `/course/quantum-hardware/density-matrix`
    - `/course/ch-algorithms/quantum-teleportation#simulating`

## Screenshots

**before**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/183793432-608f7e46-4b92-4c41-b78a-51752031977f.png">

**after**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/183793546-9355330e-55ad-48ad-b207-a205f9fe89c6.png">



