### PR TITLE
parse latex with ending period

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -247,7 +247,7 @@ def handle_markdown_cell(cell, resources, cell_number):
 
     for count, line in enumerate(lines):
         if latex:
-            if line.rstrip().endswith("$$"):
+            if line.rstrip(" .").endswith("$$"):
                 l = line.replace("$$", "")
                 markdown_lines.append(f"{l}\n" if len(l) else l)
                 markdown_lines.append("```\n")
@@ -260,7 +260,7 @@ def handle_markdown_cell(cell, resources, cell_number):
         elif line.lstrip().startswith("$$"):
             markdown_lines.append("```latex\n")
             l = line.replace("$$", "", 1)
-            if l.rstrip().endswith("$$"):
+            if l.rstrip(" .").endswith("$$"):
                 l = l.replace("$$", "")
                 markdown_lines.append(f"{l}\n" if len(l) else l)
                 markdown_lines.append("```\n")


### PR DESCRIPTION
## Changes

Fixes #1426 

preview: https://platypus-pr-1428.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/machine-learning/quantum-generative-adversarial-networks#quantum-19-0

updates the parsing of latex in markdown cells when there is a period after closing `$$`

Co-Authored-By: @frankharkins 

## Implementation details

latex is not parsed properly when a period follows the closing `$$`. this updates the parsing to take into account the potential of an existing period

## How to read this PR

- review the update to the parsing code
- go into a [page which exhibited the issue](https://platypus-pr-1428.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/machine-learning/quantum-generative-adversarial-networks#quantum-19-0) and confirm proper rendering
    - i.e., `/course/machine-learning/quantum-generative-adversarial-networks#quantum-19-0` 

## Screenshots

**before**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/183917721-284cab0d-caf7-40d7-a7e2-7bc66dfc28ec.png">

**after**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/183917904-8f209b1b-3a1a-4ad5-8714-a2f7a9d05641.png">

