### PR TITLE
Update Vale rules

### DIFF
--- a/scripts/content_checks/style/QiskitTextbook/Readability.yml
+++ b/scripts/content_checks/style/QiskitTextbook/Readability.yml
@@ -1,7 +1,7 @@
 extends: readability
 message: "Grade level (%s) is high, consider wordsmithing."
 level: suggestion
-grade: 12
+grade: 14
 metrics:
   - Flesch-Kincaid
   - Gunning Fog

--- a/scripts/content_checks/style/QiskitTextbook/ReasonWhy.yml
+++ b/scripts/content_checks/style/QiskitTextbook/ReasonWhy.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Remove 'why' in '...reason why...'."
+ignorecase: true
+level: warning
+tokens:
+  - "reason why"

--- a/scripts/content_checks/style/QiskitTextbook/ToDo.yml
+++ b/scripts/content_checks/style/QiskitTextbook/ToDo.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Found unfinished 'to do' note."
+ignorecase: true
+level: error
+tokens:
+  - TODO
+  - "To do:"

--- a/scripts/content_checks/style/QiskitTextbook/TooWordy.yml
+++ b/scripts/content_checks/style/QiskitTextbook/TooWordy.yml
@@ -128,7 +128,7 @@ tokens:
   - is applicable to
   - is authorized to
   - is responsible for
-  - it is
+  - it is(?=\s?[A-z])
   - it is essential
   - it seems that
   - it was

--- a/scripts/content_checks/style/quantum_dict.txt
+++ b/scripts/content_checks/style/quantum_dict.txt
@@ -18,7 +18,6 @@ Broughton
 Brukner
 Bucher
 Carleo
-Carleo
 Carrera
 Cerezo
 Cincio
@@ -54,14 +53,11 @@ Hoyer
 Hubregtsen
 Ijaz
 Iten
-Iten
-Izaac
 Izaac
 Jakob
 Jurcevic
 Kandala
 Keras
-Killoran
 Killoran
 Koen
 Kohli
@@ -103,7 +99,6 @@ Shewchuk
 Smelyanskiy
 Srinivasan
 Stamatopoulos
-Steenken
 Steenken
 Streif
 Sukin
@@ -150,8 +145,11 @@ fermionic
 fidelities
 hyperparameter
 hyperparameters
+ket
+kets
 minimax
 misclassifying
+nucleobase
 parameterization
 polynomially
 preprint


### PR DESCRIPTION
## Changes

- Added / tweaked a couple of Vale's rules
  - Change 'it is' rule to not match on end of sentence
  - Increase readability threshold; this should really apply to the whole notebook but at the moment we can only run it per cell, which leads to false positives
  - Add rule for pet peeve "reason why" vs just "reason"
- Added some more words to the dictionary

I made these changes while working on the quantum 301 branch, but think these belong in main.
