### PR TITLE
increase start timeout

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -17,6 +17,7 @@ liveness_check:
 
 readiness_check:
   path: "/health"
+  app_start_timeout_sec: 600
 
 env_variables:
   NODE_ENV: "production"


### PR DESCRIPTION
## Changes

the appengine start timeout was increased in hopes of addressing some recent frequent deployment failures:

- https://github.com/Qiskit/platypus/runs/8223836703?check_suite_focus=true#step:16:896
- https://github.com/Qiskit/platypus/actions/workflows/release.yml

## Implementation details

the deployment failure logs suggested increasing the [`app_start_timeout_sec`](https://cloud.google.com/appengine/docs/flexible/custom-runtimes/configuring-your-app-with-app-yaml#readiness_checks)  value:

```
try adjusting the 'app_start_timeout_sec' setting in the 'readiness_check' section
```

the variable is updated in the `app.yaml` and increased to 600 sec (double the default 300 sec)

## How to read this PR

- confirm variable is entered correctly

to see if variable actually makes a difference the PR will need to be merged and a release triggered

