### PR TITLE
fix typo in grover.ipynb

### DIFF
--- a/notebooks/ch-algorithms/grover.ipynb
+++ b/notebooks/ch-algorithms/grover.ipynb
@@ -1594,10 +1594,10 @@
    "source": [
     "#We used the W state implementation from W state in reference 6\n",
     "def control_rotation (qcir,cQbit,tQbit,theta):\n",
-    "    \"\"\" Create an intermediate controlled rotation uding only unitsry gate and controlled-NOT\n",
+    "    \"\"\" Create an intermediate controlled rotation using only unitary gate and controlled-NOT\n",
     "    \n",
     "    Args:\n",
-    "    qcir: QuantumCircuit instance to apply the controlled rotstion to.\n",
+    "    qcir: QuantumCircuit instance to apply the controlled rotation to.\n",
     "    cQbit: control qubit. \n",
     "    tQbit: target qubit.\n",
     "    theta: rotation angle.\n",

--- a/notebooks/ch-algorithms/hidden-shift-problem.ipynb
+++ b/notebooks/ch-algorithms/hidden-shift-problem.ipynb
@@ -927,7 +927,7 @@
    "id": "3c01582a",
    "metadata": {},
    "source": [
-    "As we can see, there is a significatly higher chance of measuring the hidden shift `1011`. The other results are due to errors in the quantum computation."
+    "As we can see, there is a significantly higher chance of measuring the hidden shift `1011`. The other results are due to errors in the quantum computation."
    ]
   },
   {


### PR DESCRIPTION
## Changes

fix some typos

1. grover.ipynb
uding --> using
unitsry --> unitary
rotstion --> rotation

2. hidden-shift-problem.ipynb
significatly --> significantly