### PR TITLE
Add sanity checks to notebooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
           npm run test:nb
           echo "::endgroup::"
           echo "::group::Run changed notebooks"
-          python3 ./scripts/content_checks/nb_autorun.py ${{ steps.changed-files.outputs.all_changed_files }} --fail-on-warning
+          python3 ./scripts/content_checks/nb_autorun.py ${{ steps.changed-notebooks.outputs.all_changed_files }} --fail-on-warning
           echo "::endgroup::"
 
       - name: Build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           npm run test:nb
           echo "::endgroup::"
           echo "::group::Run changed notebooks"
-          echo "${{ steps.changed-notebooks.outputs.all_changed_files }}"
+          curl https://raw.githubusercontent.com/Qiskit/platypus-binder/main/.qiskit/settings.conf --output ~/.qiskit/settings.conf
           python3 ./scripts/content_checks/nb_autorun.py ${{ steps.changed-notebooks.outputs.all_changed_files }} --fail-on-warning
           echo "::endgroup::"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
           npm run test:nb
           echo "::endgroup::"
           echo "::group::Run changed notebooks"
+          echo "${{ steps.changed-notebooks.outputs.all_changed_files }}"
           python3 ./scripts/content_checks/nb_autorun.py ${{ steps.changed-notebooks.outputs.all_changed_files }} --fail-on-warning
           echo "::endgroup::"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
           npm run test:nb
           echo "::endgroup::"
           echo "::group::Run changed notebooks"
-          curl https://raw.githubusercontent.com/Qiskit/platypus-binder/main/.qiskit/settings.conf --output ~/.qiskit/settings.conf
+          curl --create-dirs https://raw.githubusercontent.com/Qiskit/platypus-binder/main/.qiskit/settings.conf --output ~/.qiskit/settings.conf
           python3 ./scripts/content_checks/nb_autorun.py ${{ steps.changed-notebooks.outputs.all_changed_files }} --fail-on-warning
           echo "::endgroup::"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,6 @@ jobs:
           node-version: "16"
           cache: "npm"
 
-      - run: npm ci
-
       - name: Install Python 3.8
         uses: actions/setup-python@v2
         with:
@@ -40,9 +38,6 @@ jobs:
       - name: Install Python dependencies
         run: pip install -r converter/textbook-converter/requirements.txt -r converter/textbook-converter/requirements-test.txt
 
-      - name: Apply configuration
-        run: npm run setup:secrets -- --mongo ${{ secrets.STAGING_MONGODB_URI }}
-
       - name: Install Vale
         run: sudo snap install --edge vale
 
@@ -50,7 +45,7 @@ jobs:
         id: changed-notebooks
         uses: tj-actions/changed-files@v29.0.4
         with:
-          files: '**.ipynb'
+          files: notebooks/**/*.ipynb
 
       - name: Notebook tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,10 @@ jobs:
           npm run test:nb
           echo "::endgroup::"
           echo "::group::Run changed notebooks"
+          # Copy Qiskit settings
           curl --create-dirs https://raw.githubusercontent.com/Qiskit/platypus-binder/main/.qiskit/settings.conf --output ~/.qiskit/settings.conf
+          curl --create-dirs https://raw.githubusercontent.com/Qiskit/platypus-binder/main/.qiskit/styles/textbook.json --output ~/.qiskit/styles/textbook.json
+          # Run notebooks tests
           python3 ./scripts/content_checks/nb_autorun.py ${{ steps.changed-notebooks.outputs.all_changed_files }} --fail-on-warning
           echo "::endgroup::"
 

--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -582,8 +582,12 @@ class TextbookExporter(Exporter):
                     markdown_lines.append(f"\n\n---\n")
                 if headings:
                     nb_headings += headings
+                continue
 
-            elif cell.cell_type == "code" and cell.source.strip():
+            if cell.cell_type == "code" and cell.source.strip():
+                if 'sanity-check' in cell.metadata['tags']:
+                    # Ignore cell
+                    continue
                 goals, resources = handle_cell_goals(id, cell, resources)
                 if goals:
                     markdown_lines.append(f"\n---\n> id: {id}")

--- a/notebooks/.pylintrc
+++ b/notebooks/.pylintrc
@@ -17,6 +17,8 @@ good-names=
     cr
 
 additional-builtins=
+    _,
+    Out,
     display
 
 [FORMAT]

--- a/notebooks/intro/entangled-states.ipynb
+++ b/notebooks/intro/entangled-states.ipynb
@@ -350,6 +350,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d8872c0d",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"... let's begin with the two qubit |00⟩ state.\"\n",
+    "assert ket == Statevector.from_label('00')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "91f03b95",
    "metadata": {},
@@ -361,45 +376,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "b5939215",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$$ |00\\rangle$$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Latex object>"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "qc.cx(0,1)\n",
-    "\n",
-    "ket = Statevector(qc)\n",
-    "ket.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8e07947b",
-   "metadata": {},
-   "source": [
-    "This `cx` had no effect. The state remains $|00\\rangle$.\n",
-    "\n",
-    "Now let's try it with the control and target reversed."
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 3,
-   "id": "cb6fb963",
+   "id": "b5939215",
    "metadata": {},
    "outputs": [
     {
@@ -417,65 +395,41 @@
     }
    ],
    "source": [
-    "qc.cx(1,0)\n",
+    "qc.cx(0,1)\n",
     "\n",
     "ket = Statevector(qc)\n",
     "ket.draw()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ed5a11e0",
-   "metadata": {},
-   "source": [
-    "Again, no effect!\n",
-    "\n",
-    "This underwhelming performance from the `cx` is actually to be expected. We can interpret its action as being conditional on the state of the control qubit: if the control is in state $|0\\rangle$, the `cx` does nothing. If the control is in state $|1\\rangle$, the `cx` performs an `x` on the target qubit.\n",
-    "\n",
-    "![depiction of the effect of a CX gate](images/multi-qubit/cnot.svg)\n",
-    "\n",
-    "So if we want to see the `cx` do something, we need to flip the control qubit to the $|1\\rangle$ state."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "d6acd5d4",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/latex": [
-       "$$ |00\\rangle$$"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Latex object>"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "id": "2f762ccf",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
    "source": [
-    "qc.cx(1,0)\n",
-    "\n",
-    "ket = Statevector(qc)\n",
-    "ket.draw()"
+    "# \"The state remains |00⟩.\"\n",
+    "assert ket == Statevector.from_label('00')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "39f7f814",
+   "id": "8e07947b",
    "metadata": {},
    "source": [
-    "Now when we perform a `cx`, it will flip the target qubit as well."
+    "This `cx` had no effect. The state remains $|00\\rangle$.\n",
+    "\n",
+    "Now let's try it with the control and target reversed."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "cd36b606",
+   "id": "cb6fb963",
    "metadata": {},
    "outputs": [
     {
@@ -500,6 +454,129 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "91662e9d",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"Again, no effect!\"\n",
+    "assert ket == Statevector.from_label('00')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed5a11e0",
+   "metadata": {},
+   "source": [
+    "Again, no effect!\n",
+    "\n",
+    "This underwhelming performance from the `cx` is actually to be expected. We can interpret its action as being conditional on the state of the control qubit: if the control is in state $|0\\rangle$, the `cx` does nothing. If the control is in state $|1\\rangle$, the `cx` performs an `x` on the target qubit.\n",
+    "\n",
+    "![depiction of the effect of a CX gate](images/multi-qubit/cnot.svg)\n",
+    "\n",
+    "So if we want to see the `cx` do something, we need to flip the control qubit to the $|1\\rangle$ state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d6acd5d4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$ |10\\rangle$$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Latex object>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc.x(1)\n",
+    "\n",
+    "ket = Statevector(qc)\n",
+    "ket.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "b447bdf1",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...we need to flip the control qubit to the |1⟩ state.\"\n",
+    "#Leftmost qubit is control\n",
+    "assert ket == Statevector.from_label('10')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39f7f814",
+   "metadata": {},
+   "source": [
+    "Now when we perform a `cx`, it will flip the target qubit as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "cd36b606",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$$ |11\\rangle$$"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Latex object>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "qc.cx(1,0)\n",
+    "\n",
+    "ket = Statevector(qc)\n",
+    "ket.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "6b7169e0",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...it will flip the target qubit as well.\"\n",
+    "# Both qubits should be |1⟩\n",
+    "assert ket == Statevector.from_label('11')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "7daee78a",
    "metadata": {},
@@ -509,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "id": "4ebba41b",
    "metadata": {},
    "outputs": [
@@ -522,7 +599,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -538,6 +615,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "6fe2bd42",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...suppose we have the |+0⟩ state from before.\"\n",
+    "assert ket == Statevector.from_label('+0')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "b83b951e",
    "metadata": {},
@@ -547,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 13,
    "id": "ff21ff83",
    "metadata": {},
    "outputs": [
@@ -560,7 +652,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -610,7 +702,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "id": "c00e5baa",
    "metadata": {},
    "outputs": [
@@ -623,7 +715,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -639,6 +731,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "613e4e20",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...both qubits are in the |+⟩ state.\"\n",
+    "assert ket == Statevector.from_label('++')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "246fbb0e",
    "metadata": {},
@@ -648,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 16,
    "id": "ddafa061",
    "metadata": {},
    "outputs": [
@@ -661,7 +768,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,6 +778,21 @@
     "\n",
     "ket = Statevector(qc)\n",
     "ket.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "47220ee0",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...the cx has no effect...\"\n",
+    "assert Out[14].data == Out[16].data"
    ]
   },
   {
@@ -683,7 +805,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 18,
    "id": "71af42c3",
    "metadata": {},
    "outputs": [
@@ -696,7 +818,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -709,6 +831,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "4b4b0c32",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...let's now flip the target qubit from |+⟩ to |−⟩...\"\n",
+    "# Rightmost is target\n",
+    "assert ket == Statevector.from_label('+-')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "f30c1776",
    "metadata": {},
@@ -718,7 +856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 20,
    "id": "ff79a3df",
    "metadata": {},
    "outputs": [
@@ -731,7 +869,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -741,6 +879,21 @@
     "\n",
     "ket = Statevector(qc)\n",
     "ket.draw()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "abb4be57",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"It flips the control qubit to |−⟩ as well.\"\n",
+    "assert ket == Statevector.from_label('--')"
    ]
   },
   {
@@ -794,7 +947,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 22,
    "id": "5131b1ac",
    "metadata": {},
    "outputs": [],
@@ -820,7 +973,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 23,
    "id": "23cdaedf",
    "metadata": {},
    "outputs": [
@@ -830,7 +983,7 @@
        "{'00': 1024}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -847,6 +1000,22 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "73ebcdab",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"The result Bob gets out will be exactly what Alice put in..\"\n",
+    "# Check only result is MESSAGE\n",
+    "assert list(_.keys()) == [MESSAGE]"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "f96206c6",
    "metadata": {},
@@ -858,7 +1027,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 25,
    "id": "e9576a06",
    "metadata": {},
    "outputs": [
@@ -871,7 +1040,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -896,6 +1065,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "111de90a",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"For a message 00, the state created by these gates is |Φ+⟩.\"\n",
+    "from numpy import sqrt as _sqrt\n",
+    "assert MESSAGE == '00'\n",
+    "assert ket == Statevector([1/_sqrt(2), 0, 0, 1/_sqrt(2)])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "dffbee55",
    "metadata": {},
@@ -909,17 +1095,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 27,
    "id": "f3a2a6dd",
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"266.38pt\" height=\"172pt\" version=\"1.1\" viewBox=\"0 0 266.38 172\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 172h266.38v-172h-266.38z\" fill=\"#ffffff\"/><path d=\"m176.21 126.45h12.052l-6.026 8.6914z\" clip-path=\"url(#p3a9152b269)\" fill=\"#778899\"/><path d=\"m222.56 126.45h12.052l-6.026 8.6914z\" clip-path=\"url(#p3a9152b269)\" fill=\"#778899\"/><path d=\"m64.497 44.283h190.05\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 90.637h190.05\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 135.48h190.05\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 138.5h190.05\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m73.768 141.63 4.6354-9.2708\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m89.528 90.637v-46.354\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#1192e8\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m183.74 44.283v82.162\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m180.73 44.283v82.162\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m230.1 90.637v35.808\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m227.08 90.637v35.808\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m89.528 95.157c1.1986 0 2.3482-0.4762 3.1958-1.3237 0.84753-0.84753 1.3237-1.9972 1.3237-3.1958s-0.4762-2.3482-1.3237-3.1958c-0.84753-0.84753-1.9972-1.3237-3.1958-1.3237-1.1986 0-2.3482 0.4762-3.1958 1.3237-0.84753 0.84753-1.3237 1.9972-1.3237 3.1958s0.4762 2.3482 1.3237 3.1958c0.84753 0.84753 1.9972 1.3237 3.1958 1.3237z\" clip-path=\"url(#p3a9152b269)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m89.528 54.829c2.7967 0 5.4792-1.1111 7.4568-3.0887 1.9776-1.9776 3.0887-4.6601 3.0887-7.4568 0-2.7967-1.1111-5.4792-3.0887-7.4568-1.9776-1.9776-4.6601-3.0887-7.4568-3.0887-2.7967 0-5.4792 1.1111-7.4568 3.0887-1.9776 1.9776-3.0887 4.6601-3.0887 7.4568 0 2.7967 1.1111 5.4792 3.0887 7.4568 1.9776 1.9776 4.6601 3.0887 7.4568 3.0887z\" clip-path=\"url(#p3a9152b269)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"2\"/><path d=\"m120.82 105.7h30.13v-30.13h-30.13z\" clip-path=\"url(#p3a9152b269)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m167.17 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p3a9152b269)\" fill=\"#121619\" stroke=\"#121619\" stroke-width=\"1.5\"/><path d=\"m192.78 48.803c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887-5.4799 1.1118-7.4568 3.0887-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"2\"/><path d=\"m182.24 48.803 10.546-10.546\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m213.53 105.7h30.13v-30.13h-30.13z\" clip-path=\"url(#p3a9152b269)\" fill=\"#121619\" stroke=\"#121619\" stroke-width=\"1.5\"/><path d=\"m239.14 95.157c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887-5.4799 1.1118-7.4568 3.0887-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"2\"/><path d=\"m228.59 95.157 10.546-10.546\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(37.189 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(37.189 95.088) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(69.133 130.19) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/></g></g><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(46.291 141.48) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><path d=\"m89.528 50.309v-12.052\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m83.502 44.283h12.052\" clip-path=\"url(#p3a9152b269)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(130.99 94.224) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-48\" transform=\"scale(.015625)\" d=\"m628 4666h631v-1913h2294v1913h631v-4666h-631v2222h-2294v-2222h-631v4666z\"/></defs><use xlink:href=\"#DejaVuSans-48\"/></g></g><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(193.82 130.19) scale(.104 -.104)\"><use xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#p3a9152b269)\"><g transform=\"translate(240.18 130.19) scale(.104 -.104)\"><use xlink:href=\"#DejaVuSans-31\"/></g></g><defs><clipPath id=\"p3a9152b269\"><rect x=\"7.2\" y=\"7.2\" width=\"251.98\" height=\"157.6\"/></clipPath></defs></svg>"
+      ],
       "text/plain": [
-       "<qiskit.circuit.instructionset.InstructionSet at 0x141c7ad60>"
+       "<Figure size 454.517x284.278 with 1 Axes>"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -930,7 +1119,9 @@
     "qc_bob.cx(1,0)\n",
     "qc_bob.h(1)\n",
     "# Then measures\n",
-    "qc_bob.measure([0,1],[0,1])"
+    "qc_bob.measure([0,1],[0,1])\n",
+    "\n",
+    "qc_bob.draw()"
    ]
   },
   {
@@ -945,7 +1136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 28,
    "id": "f605c409",
    "metadata": {},
    "outputs": [
@@ -958,7 +1149,7 @@
        "<IPython.core.display.Latex object>"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -989,7 +1180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 29,
    "id": "1d527688",
    "metadata": {},
    "outputs": [
@@ -999,13 +1190,29 @@
        "{'00': 1024}"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "backend.run(qc_alice.compose(qc_bob)).result().get_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "960ce9d9",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...[Bob] doesn't need to change his circuit at all.\"\n",
+    "# This implies Bob should still only measure MESSAGE\n",
+    "assert list(_.keys()) == [MESSAGE]"
    ]
   },
   {
@@ -1020,17 +1227,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 31,
    "id": "396caed9",
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"173.68pt\" height=\"172pt\" version=\"1.1\" viewBox=\"0 0 173.68 172\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m-0 172h173.68v-172h-173.68z\" fill=\"#ffffff\"/><path d=\"m64.497 44.283h97.343\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 90.637h97.343\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 135.48h97.343\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 138.5h97.343\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m73.768 141.63 4.6354-9.2708\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m135.88 90.637v-46.354\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#1192e8\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m74.463 105.7h30.13v-30.13h-30.13z\" clip-path=\"url(#p4bf2693d24)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m135.88 95.157c1.1986 0 2.3482-0.4762 3.1958-1.3237 0.84753-0.84753 1.3237-1.9972 1.3237-3.1958s-0.4762-2.3482-1.3237-3.1958c-0.84753-0.84753-1.9972-1.3237-3.1958-1.3237-1.1986 0-2.3482 0.4762-3.1958 1.3237-0.84753 0.84753-1.3237 1.9972-1.3237 3.1958s0.4762 2.3482 1.3237 3.1958c0.84753 0.84753 1.9972 1.3237 3.1958 1.3237z\" clip-path=\"url(#p4bf2693d24)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m135.88 54.829c2.7967 0 5.4792-1.1111 7.4568-3.0887 1.9776-1.9776 3.0887-4.6601 3.0887-7.4568 0-2.7967-1.1111-5.4792-3.0887-7.4568-1.9776-1.9776-4.6601-3.0887-7.4568-3.0887-2.7967 0-5.4792 1.1111-7.4568 3.0887-1.9776 1.9776-3.0887 4.6601-3.0887 7.4568 0 2.7967 1.1111 5.4792 3.0887 7.4568 1.9776 1.9776 4.6601 3.0887 7.4568 3.0887z\" clip-path=\"url(#p4bf2693d24)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"2\"/><g clip-path=\"url(#p4bf2693d24)\"><g transform=\"translate(37.189 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#p4bf2693d24)\"><g transform=\"translate(37.189 95.088) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p4bf2693d24)\"><g transform=\"translate(69.133 130.19) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/></g></g><g clip-path=\"url(#p4bf2693d24)\"><g transform=\"translate(46.291 141.48) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p4bf2693d24)\"><g transform=\"translate(84.64 94.224) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-48\" transform=\"scale(.015625)\" d=\"m628 4666h631v-1913h2294v1913h631v-4666h-631v2222h-2294v-2222h-631v4666z\"/></defs><use xlink:href=\"#DejaVuSans-48\"/></g></g><path d=\"m135.88 50.309v-12.052\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m129.86 44.283h12.052\" clip-path=\"url(#p4bf2693d24)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><defs><clipPath id=\"p4bf2693d24\"><rect x=\"7.2\" y=\"7.2\" width=\"159.28\" height=\"157.6\"/></clipPath></defs></svg>"
+      ],
       "text/plain": [
-       "<qiskit.circuit.instructionset.InstructionSet at 0x141c7ac40>"
+       "<Figure size 287.294x284.278 with 1 Axes>"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1039,7 +1249,9 @@
     "qc_charlie = QuantumCircuit(2,2)\n",
     "\n",
     "qc_charlie.h(1)\n",
-    "qc_charlie.cx(1,0)"
+    "qc_charlie.cx(1,0)\n",
+    "\n",
+    "qc_charlie.draw()"
    ]
   },
   {
@@ -1054,7 +1266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 32,
    "id": "c932672e",
    "metadata": {},
    "outputs": [],
@@ -1079,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 33,
    "id": "2e3282be",
    "metadata": {},
    "outputs": [
@@ -1089,7 +1301,7 @@
        "{'01': 1024}"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1097,6 +1309,22 @@
    "source": [
     "complete_qc = qc_charlie.compose(qc_alice.compose(qc_bob))\n",
     "backend.run(complete_qc).result().get_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "282ee6f2",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"Now Bob can apply the same process as before and extract\n",
+    "# the message from his two qubits.\"\n",
+    "assert list(_.keys()) == [MESSAGE]"
    ]
   },
   {
@@ -1166,20 +1394,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 35,
    "id": "2fabbe42",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"163.57pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 163.57 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h163.57v-125.65h-163.57z\" fill=\"#ffffff\"/><path d=\"m119.75 80.092h12.052l-6.026 8.6914z\" clip-path=\"url(#pc51347689f)\" fill=\"#778899\"/><path d=\"m54.39 44.283h97.343\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h97.343\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h97.343\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m127.28 44.283v35.808\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m124.27 44.283v35.808\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#pc51347689f)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m110.71 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#pc51347689f)\" fill=\"#121619\" stroke=\"#121619\" stroke-width=\"1.5\"/><path d=\"m136.32 48.803c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887c-2.7958 0-5.4799 1.1118-7.4568 3.0887s-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"2\"/><path d=\"m125.78 48.803 10.546-10.546\" clip-path=\"url(#pc51347689f)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#pc51347689f)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#pc51347689f)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#pc51347689f)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#pc51347689f)\"><g transform=\"translate(74.533 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-48\" transform=\"scale(.015625)\" d=\"m628 4666h631v-1913h2294v1913h631v-4666h-631v2222h-2294v-2222h-631v4666z\"/></defs><use xlink:href=\"#DejaVuSans-48\"/></g></g><g clip-path=\"url(#pc51347689f)\"><g transform=\"translate(137.36 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/></g></g><defs><clipPath id=\"pc51347689f\"><rect x=\"7.2\" y=\"7.2\" width=\"149.17\" height=\"111.25\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"163.57pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 163.57 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h163.57v-125.65h-163.57z\" fill=\"#ffffff\"/><path d=\"m119.75 80.092h12.052l-6.026 8.6914z\" clip-path=\"url(#pa765e4dfa5)\" fill=\"#778899\"/><path d=\"m54.39 44.283h97.343\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h97.343\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h97.343\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m127.28 44.283v35.808\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m124.27 44.283v35.808\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#pa765e4dfa5)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m110.71 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#pa765e4dfa5)\" fill=\"#121619\" stroke=\"#121619\" stroke-width=\"1.5\"/><path d=\"m136.32 48.803c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887c-2.7958 0-5.4799 1.1118-7.4568 3.0887s-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"2\"/><path d=\"m125.78 48.803 10.546-10.546\" clip-path=\"url(#pa765e4dfa5)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#pa765e4dfa5)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#pa765e4dfa5)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#pa765e4dfa5)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#pa765e4dfa5)\"><g transform=\"translate(74.533 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-48\" transform=\"scale(.015625)\" d=\"m628 4666h631v-1913h2294v1913h631v-4666h-631v2222h-2294v-2222h-631v4666z\"/></defs><use xlink:href=\"#DejaVuSans-48\"/></g></g><g clip-path=\"url(#pa765e4dfa5)\"><g transform=\"translate(137.36 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/></g></g><defs><clipPath id=\"pa765e4dfa5\"><rect x=\"7.2\" y=\"7.2\" width=\"149.17\" height=\"111.25\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 269.064x200.667 with 1 Axes>"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1202,20 +1430,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 36,
    "id": "1787d8fa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m73.395 80.092h12.052l-6.026 8.6914z\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"#778899\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m80.928 44.283v35.808\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m77.915 44.283v35.808\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"#121619\" stroke=\"#121619\" stroke-width=\"1.5\"/><path d=\"m89.967 48.803c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887-5.4799 1.1118-7.4568 3.0887-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"2\"/><path d=\"m79.421 48.803 10.546-10.546\" clip-path=\"url(#p72d9cfc1d4)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p72d9cfc1d4)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p72d9cfc1d4)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p72d9cfc1d4)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p72d9cfc1d4)\"><g transform=\"translate(91.01 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/></g></g><defs><clipPath id=\"p72d9cfc1d4\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m73.395 80.092h12.052l-6.026 8.6914z\" clip-path=\"url(#p47a8236f18)\" fill=\"#778899\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m80.928 44.283v35.808\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m77.915 44.283v35.808\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p47a8236f18)\" fill=\"#121619\" stroke=\"#121619\" stroke-width=\"1.5\"/><path d=\"m89.967 48.803c0-2.7958-1.1118-5.4799-3.0887-7.4568s-4.661-3.0887-7.4568-3.0887-5.4799 1.1118-7.4568 3.0887-3.0887 4.661-3.0887 7.4568\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#ffffff\" stroke-width=\"2\"/><path d=\"m79.421 48.803 10.546-10.546\" clip-path=\"url(#p47a8236f18)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p47a8236f18)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p47a8236f18)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p47a8236f18)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p47a8236f18)\"><g transform=\"translate(91.01 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/></g></g><defs><clipPath id=\"p47a8236f18\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 185.453x200.667 with 1 Axes>"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1239,20 +1467,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 37,
    "id": "246a35c2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"94.038pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 94.038 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h94.038v-125.65h-94.038z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h27.812\" clip-path=\"url(#p030aab8c84)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h27.812\" clip-path=\"url(#p030aab8c84)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h27.812\" clip-path=\"url(#p030aab8c84)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p030aab8c84)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><g clip-path=\"url(#p030aab8c84)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p030aab8c84)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p030aab8c84)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><defs><clipPath id=\"p030aab8c84\"><rect x=\"7.2\" y=\"7.2\" width=\"79.638\" height=\"111.25\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"94.038pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 94.038 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h94.038v-125.65h-94.038z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h27.812\" clip-path=\"url(#p921622bebf)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h27.812\" clip-path=\"url(#p921622bebf)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h27.812\" clip-path=\"url(#p921622bebf)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p921622bebf)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><g clip-path=\"url(#p921622bebf)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p921622bebf)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p921622bebf)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><defs><clipPath id=\"p921622bebf\"><rect x=\"7.2\" y=\"7.2\" width=\"79.638\" height=\"111.25\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 143.647x200.667 with 1 Axes>"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1273,7 +1501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 38,
    "id": "208444c6",
    "metadata": {},
    "outputs": [
@@ -1286,8 +1514,23 @@
     }
    ],
    "source": [
-    "print('Results from z measurement:',\n",
-    "      backend.run(qc.compose(meas_z)).result().get_counts())"
+    "z_meas_counts = backend.run(qc.compose(meas_z)).result().get_counts()\n",
+    "print('Results from z measurement:', z_meas_counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "2728e161",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...this is certain to output 0.\"\n",
+    "assert list(z_meas_counts.keys()) == ['0']"
    ]
   },
   {
@@ -1300,7 +1543,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 40,
    "id": "3e9f9d2e",
    "metadata": {},
    "outputs": [
@@ -1308,13 +1551,29 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Results from x measurement: {'0': 509, '1': 515}\n"
+      "Results from x measurement: {'1': 524, '0': 500}\n"
      ]
     }
    ],
    "source": [
-    "print('Results from x measurement:',\n",
-    "      backend.run(qc.compose(meas_x)).result().get_counts())"
+    "x_meas_counts = backend.run(qc.compose(meas_x)).result().get_counts()\n",
+    "print('Results from x measurement:', x_meas_counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "ca15b871",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...we'll get completely random results.\"\n",
+    "assert x_meas_counts['0'] > x_meas_counts['1']*0.9\n",
+    "assert x_meas_counts['0'] < x_meas_counts['1']*1.1"
    ]
   },
   {
@@ -1327,20 +1586,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 42,
    "id": "88b56117",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#p6e7b08ba3f)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#p6e7b08ba3f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#p6e7b08ba3f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p6e7b08ba3f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p6e7b08ba3f)\" fill=\"#005d5d\" stroke=\"#005d5d\" stroke-width=\"1.5\"/><g clip-path=\"url(#p6e7b08ba3f)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p6e7b08ba3f)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p6e7b08ba3f)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p6e7b08ba3f)\"><g transform=\"translate(74.969 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-58\" transform=\"scale(.015625)\" d=\"m403 4666h678l1160-1735 1165 1735h678l-1500-2241 1600-2425h-678l-1312 1984-1322-1984h-681l1665 2491-1453 2175z\"/></defs><use xlink:href=\"#DejaVuSans-58\"/></g></g><defs><clipPath id=\"p6e7b08ba3f\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#pf29fbee233)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#pf29fbee233)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#pf29fbee233)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#pf29fbee233)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#pf29fbee233)\" fill=\"#005d5d\" stroke=\"#005d5d\" stroke-width=\"1.5\"/><g clip-path=\"url(#pf29fbee233)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#pf29fbee233)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#pf29fbee233)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#pf29fbee233)\"><g transform=\"translate(74.969 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-58\" transform=\"scale(.015625)\" d=\"m403 4666h678l1160-1735 1165 1735h678l-1500-2241 1600-2425h-678l-1312 1984-1322-1984h-681l1665 2491-1453 2175z\"/></defs><use xlink:href=\"#DejaVuSans-58\"/></g></g><defs><clipPath id=\"pf29fbee233\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 185.453x200.667 with 1 Axes>"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1362,7 +1621,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 43,
    "id": "a3140d05",
    "metadata": {},
    "outputs": [
@@ -1371,7 +1630,7 @@
      "output_type": "stream",
      "text": [
       "Results from z measurement: {'1': 1024}\n",
-      "Results from x measurement: {'0': 510, '1': 514}\n"
+      "Results from x measurement: {'0': 522, '1': 502}\n"
      ]
     }
    ],
@@ -1391,20 +1650,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 44,
    "id": "d6492859",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#p23be3acfae)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#p23be3acfae)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#p23be3acfae)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p23be3acfae)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p23be3acfae)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><g clip-path=\"url(#p23be3acfae)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p23be3acfae)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p23be3acfae)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p23be3acfae)\"><g transform=\"translate(74.533 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-48\" transform=\"scale(.015625)\" d=\"m628 4666h631v-1913h2294v1913h631v-4666h-631v2222h-2294v-2222h-631v4666z\"/></defs><use xlink:href=\"#DejaVuSans-48\"/></g></g><defs><clipPath id=\"p23be3acfae\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#p2ad1e9ba7f)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#p2ad1e9ba7f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#p2ad1e9ba7f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p2ad1e9ba7f)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p2ad1e9ba7f)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><g clip-path=\"url(#p2ad1e9ba7f)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p2ad1e9ba7f)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p2ad1e9ba7f)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p2ad1e9ba7f)\"><g transform=\"translate(74.533 47.87) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-48\" transform=\"scale(.015625)\" d=\"m628 4666h631v-1913h2294v1913h631v-4666h-631v2222h-2294v-2222h-631v4666z\"/></defs><use xlink:href=\"#DejaVuSans-48\"/></g></g><defs><clipPath id=\"p2ad1e9ba7f\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 185.453x200.667 with 1 Axes>"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1426,7 +1685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 45,
    "id": "75b5e22a",
    "metadata": {},
    "outputs": [
@@ -1434,7 +1693,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Results from z measurement: {'1': 511, '0': 513}\n",
+      "Results from z measurement: {'0': 528, '1': 496}\n",
       "Results from x measurement: {'0': 1024}\n"
      ]
     }
@@ -1501,17 +1760,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 46,
    "id": "a394eb5f",
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "image/svg+xml": [
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"117.22pt\" height=\"125.65pt\" version=\"1.1\" viewBox=\"0 0 117.22 125.65\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 125.65h117.22v-125.65h-117.22z\" fill=\"#ffffff\"/><path d=\"m54.39 44.283h50.989\" clip-path=\"url(#p48c58c1046)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 89.131h50.989\" clip-path=\"url(#p48c58c1046)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m54.39 92.144h50.989\" clip-path=\"url(#p48c58c1046)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m63.661 95.273 4.6354-9.2708\" clip-path=\"url(#p48c58c1046)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m64.356 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p48c58c1046)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><g clip-path=\"url(#p48c58c1046)\"><g transform=\"translate(34.719 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/></g></g><g clip-path=\"url(#p48c58c1046)\"><g transform=\"translate(59.026 83.839) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p48c58c1046)\"><g transform=\"translate(36.184 95.121) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p48c58c1046)\"><g transform=\"translate(69.741 55.53) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-2212\" transform=\"scale(.015625)\" d=\"m678 2272h4006v-531h-4006v531z\"/><path id=\"DejaVuSans-Oblique-3c0\" transform=\"scale(.015625)\" d=\"m584 3500h3354l-113-575h-441l-418-2150q-44-225 15-325 57-97 228-97 47 0 116 10 72 6 94 9l-81-416q-116-40-235-59-122-19-237-19-375 0-478 203-104 207 3 757l406 2087h-1291l-568-2925h-588l569 2925h-447l112 575z\"/><path id=\"DejaVuSans-2f\" transform=\"scale(.015625)\" d=\"m1625 4666h531l-1625-5260h-531l1625 5260z\"/><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-2212\"/><use transform=\"translate(83.789 .09375)\" xlink:href=\"#DejaVuSans-Oblique-3c0\"/><use transform=\"translate(143.99 .09375)\" xlink:href=\"#DejaVuSans-2f\"/><use transform=\"translate(177.69 .09375)\" xlink:href=\"#DejaVuSans-34\"/></g></g><g clip-path=\"url(#p48c58c1046)\"><g transform=\"translate(71.881 43.351) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-52\" transform=\"scale(.015625)\" d=\"m2841 2188q203-69 395-294t386-619l641-1275h-679l-596 1197q-232 469-449 622t-592 153h-688v-1972h-631v4666h1425q800 0 1194-335 394-334 394-1009 0-441-205-732-205-290-595-402zm-1582 1959v-1656h794q456 0 689 211t233 620-233 617-689 208h-794z\"/><path id=\"DejaVuSans-59\" transform=\"scale(.015625)\" d=\"m-13 4666h679l1293-1919 1285 1919h678l-1650-2444v-2222h-634v2222l-1651 2444z\"/></defs><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><defs><clipPath id=\"p48c58c1046\"><rect x=\"7.2\" y=\"7.2\" width=\"102.82\" height=\"111.25\"/></clipPath></defs></svg>"
+      ],
       "text/plain": [
-       "<qiskit.circuit.instructionset.InstructionSet at 0x1432bb5b0>"
+       "<Figure size 185.453x200.667 with 1 Axes>"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1520,7 +1782,9 @@
     "from math import pi\n",
     "\n",
     "qc = QuantumCircuit(1, 1)\n",
-    "qc.ry(-pi/4, 0)"
+    "qc.ry(-pi/4, 0)\n",
+    "\n",
+    "qc.draw()"
    ]
   },
   {
@@ -1533,7 +1797,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 47,
    "id": "e4b4c0be",
    "metadata": {},
    "outputs": [
@@ -1541,8 +1805,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Results from z measurement: {'1': 138, '0': 886}\n",
-      "Results from x measurement: {'0': 135, '1': 889}\n"
+      "Results from z measurement: {'1': 153, '0': 871}\n",
+      "Results from x measurement: {'0': 161, '1': 863}\n"
      ]
     }
    ],
@@ -1611,20 +1875,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 48,
    "id": "5c6e5958",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"312.74pt\" height=\"172pt\" version=\"1.1\" viewBox=\"0 0 312.74 172\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 172h312.74v-172h-312.74z\" fill=\"#ffffff\"/><path d=\"m64.497 44.283h236.41\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 90.637h236.41\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 135.48h236.41\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 138.5h236.41\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m73.768 141.63 4.6354-9.2708\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m135.88 90.637v-46.354\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#1192e8\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m228.59 90.637v-46.354\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#1192e8\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m74.463 105.7h30.13v-30.13h-30.13z\" clip-path=\"url(#p320755a7e0)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><path d=\"m135.88 95.157c1.1986 0 2.3482-0.4762 3.1958-1.3237 0.84753-0.84753 1.3237-1.9972 1.3237-3.1958s-0.4762-2.3482-1.3237-3.1958c-0.84753-0.84753-1.9972-1.3237-3.1958-1.3237-1.1986 0-2.3482 0.4762-3.1958 1.3237-0.84753 0.84753-1.3237 1.9972-1.3237 3.1958s0.4762 2.3482 1.3237 3.1958c0.84753 0.84753 1.9972 1.3237 3.1958 1.3237z\" clip-path=\"url(#p320755a7e0)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m135.88 54.829c2.7967 0 5.4792-1.1111 7.4568-3.0887 1.9776-1.9776 3.0887-4.6601 3.0887-7.4568 0-2.7967-1.1111-5.4792-3.0887-7.4568-1.9776-1.9776-4.6601-3.0887-7.4568-3.0887-2.7967 0-5.4792 1.1111-7.4568 3.0887-1.9776 1.9776-3.0887 4.6601-3.0887 7.4568 0 2.7967 1.1111 5.4792 3.0887 7.4568 1.9776 1.9776 4.6601 3.0887 7.4568 3.0887z\" clip-path=\"url(#p320755a7e0)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"2\"/><path d=\"m167.17 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p320755a7e0)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><path d=\"m228.59 95.157c1.1986 0 2.3482-0.4762 3.1958-1.3237 0.84753-0.84753 1.3237-1.9972 1.3237-3.1958s-0.4762-2.3482-1.3237-3.1958c-0.84753-0.84753-1.9972-1.3237-3.1958-1.3237-1.1986 0-2.3482 0.4762-3.1958 1.3237-0.84753 0.84753-1.3237 1.9972-1.3237 3.1958s0.4762 2.3482 1.3237 3.1958c0.84753 0.84753 1.9972 1.3237 3.1958 1.3237z\" clip-path=\"url(#p320755a7e0)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m228.59 54.829c2.7967 0 5.4792-1.1111 7.4568-3.0887 1.9776-1.9776 3.0887-4.6601 3.0887-7.4568 0-2.7967-1.1111-5.4792-3.0887-7.4568-1.9776-1.9776-4.6601-3.0887-7.4568-3.0887-2.7967 0-5.4792 1.1111-7.4568 3.0887-1.9776 1.9776-3.0887 4.6601-3.0887 7.4568 0 2.7967 1.1111 5.4792 3.0887 7.4568 1.9776 1.9776 4.6601 3.0887 7.4568 3.0887z\" clip-path=\"url(#p320755a7e0)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"2\"/><path d=\"m259.88 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p320755a7e0)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(37.189 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(37.189 95.088) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(69.133 130.19) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(46.291 141.48) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(80.622 101.88) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/><path id=\"DejaVuSans-39\" transform=\"scale(.015625)\" d=\"m703 97v575q238-113 481-172 244-59 479-59 625 0 954 420 330 420 377 1277-181-269-460-413-278-144-615-144-700 0-1108 423-408 424-408 1159 0 718 425 1152 425 435 1131 435 810 0 1236-621 427-620 427-1801 0-1103-524-1761-523-658-1407-658-238 0-482 47-243 47-506 141zm1256 1978q425 0 673 290 249 291 249 798 0 503-249 795-248 292-673 292t-673-292-248-795q0-507 248-798 248-290 673-290z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-39\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(81.988 89.705) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-52\" transform=\"scale(.015625)\" d=\"m2841 2188q203-69 395-294t386-619l641-1275h-679l-596 1197q-232 469-449 622t-592 153h-688v-1972h-631v4666h1425q800 0 1194-335 394-334 394-1009 0-441-205-732-205-290-595-402zm-1582 1959v-1656h794q456 0 689 211t233 620-233 617-689 208h-794z\"/><path id=\"DejaVuSans-59\" transform=\"scale(.015625)\" d=\"m-13 4666h679l1293-1919 1285 1919h678l-1650-2444v-2222h-634v2222l-1651 2444z\"/></defs><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><path d=\"m135.88 50.309v-12.052\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m129.86 44.283h12.052\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(170.79 55.53) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/><path id=\"DejaVuSans-35\" transform=\"scale(.015625)\" d=\"m691 4666h2478v-532h-1900v-1143q137 47 274 70 138 23 276 23 781 0 1237-428 457-428 457-1159 0-753-469-1171-469-417-1322-417-294 0-599 50-304 50-629 150v635q281-153 581-228t634-75q541 0 856 284 316 284 316 772 0 487-316 771-315 285-856 285-253 0-505-56-251-56-513-175v2344z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-37\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-38\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-35\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(174.7 43.351) scale(.13 -.13)\" fill=\"#ffffff\"><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><path d=\"m228.59 50.309v-12.052\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m222.56 44.283h12.052\" clip-path=\"url(#p320755a7e0)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(266.04 55.53) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-33\" transform=\"scale(.015625)\" d=\"m2597 2516q453-97 707-404 255-306 255-756 0-690-475-1069-475-378-1350-378-293 0-604 58t-642 174v609q262-153 574-231 313-78 654-78 593 0 904 234t311 681q0 413-289 645-289 233-804 233h-544v519h569q465 0 712 186t247 536q0 359-255 551-254 193-729 193-260 0-557-57-297-56-653-174v562q360 100 674 150t592 50q719 0 1137-327 419-326 419-882 0-388-222-655t-631-370z\"/><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/></g></g><g clip-path=\"url(#p320755a7e0)\"><g transform=\"translate(267.4 43.351) scale(.13 -.13)\" fill=\"#ffffff\"><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><defs><clipPath id=\"p320755a7e0\"><rect x=\"7.2\" y=\"7.2\" width=\"298.34\" height=\"157.6\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"312.74pt\" height=\"172pt\" version=\"1.1\" viewBox=\"0 0 312.74 172\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 172h312.74v-172h-312.74z\" fill=\"#ffffff\"/><path d=\"m64.497 44.283h236.41\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 90.637h236.41\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#000000\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 135.48h236.41\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m64.497 138.5h236.41\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m73.768 141.63 4.6354-9.2708\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#778899\" stroke-linecap=\"square\"/><path d=\"m135.88 90.637v-46.354\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#1192e8\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m228.59 90.637v-46.354\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#1192e8\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m74.463 105.7h30.13v-30.13h-30.13z\" clip-path=\"url(#p88131df891)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><path d=\"m135.88 95.157c1.1986 0 2.3482-0.4762 3.1958-1.3237 0.84753-0.84753 1.3237-1.9972 1.3237-3.1958s-0.4762-2.3482-1.3237-3.1958c-0.84753-0.84753-1.9972-1.3237-3.1958-1.3237-1.1986 0-2.3482 0.4762-3.1958 1.3237-0.84753 0.84753-1.3237 1.9972-1.3237 3.1958s0.4762 2.3482 1.3237 3.1958c0.84753 0.84753 1.9972 1.3237 3.1958 1.3237z\" clip-path=\"url(#p88131df891)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m135.88 54.829c2.7967 0 5.4792-1.1111 7.4568-3.0887 1.9776-1.9776 3.0887-4.6601 3.0887-7.4568 0-2.7967-1.1111-5.4792-3.0887-7.4568-1.9776-1.9776-4.6601-3.0887-7.4568-3.0887-2.7967 0-5.4792 1.1111-7.4568 3.0887-1.9776 1.9776-3.0887 4.6601-3.0887 7.4568 0 2.7967 1.1111 5.4792 3.0887 7.4568 1.9776 1.9776 4.6601 3.0887 7.4568 3.0887z\" clip-path=\"url(#p88131df891)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"2\"/><path d=\"m167.17 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p88131df891)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><path d=\"m228.59 95.157c1.1986 0 2.3482-0.4762 3.1958-1.3237 0.84753-0.84753 1.3237-1.9972 1.3237-3.1958s-0.4762-2.3482-1.3237-3.1958c-0.84753-0.84753-1.9972-1.3237-3.1958-1.3237-1.1986 0-2.3482 0.4762-3.1958 1.3237-0.84753 0.84753-1.3237 1.9972-1.3237 3.1958s0.4762 2.3482 1.3237 3.1958c0.84753 0.84753 1.9972 1.3237 3.1958 1.3237z\" clip-path=\"url(#p88131df891)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"1.5\"/><path d=\"m228.59 54.829c2.7967 0 5.4792-1.1111 7.4568-3.0887 1.9776-1.9776 3.0887-4.6601 3.0887-7.4568 0-2.7967-1.1111-5.4792-3.0887-7.4568-1.9776-1.9776-4.6601-3.0887-7.4568-3.0887-2.7967 0-5.4792 1.1111-7.4568 3.0887-1.9776 1.9776-3.0887 4.6601-3.0887 7.4568 0 2.7967 1.1111 5.4792 3.0887 7.4568 1.9776 1.9776 4.6601 3.0887 7.4568 3.0887z\" clip-path=\"url(#p88131df891)\" fill=\"#1192e8\" stroke=\"#1192e8\" stroke-width=\"2\"/><path d=\"m259.88 59.348h30.13v-30.13h-30.13z\" clip-path=\"url(#p88131df891)\" fill=\"#6929c4\" stroke=\"#6929c4\" stroke-width=\"1.5\"/><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(37.189 48.734) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-Oblique-71\" transform=\"scale(.015625)\" d=\"m2669 525q-231-303-546-460-314-156-695-156-531 0-833 358-301 358-301 986 0 506 186 978t533 847q225 244 517 375t614 131q387 0 637-153t363-462l100 525h578l-934-4813h-579l360 1844zm-1778 813q0-463 193-705 194-242 560-242 544 0 928 520t384 1264q0 450-199 689-198 239-569 239-272 0-504-127-231-126-403-370-181-256-286-600-104-343-104-668z\"/><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-30\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(37.189 95.088) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-Oblique-71\"/><use transform=\"translate(63.477 -16.406) scale(.7)\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(69.133 130.19) scale(.104 -.104)\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(46.291 141.48) scale(.1625 -.1625)\"><defs><path id=\"DejaVuSans-63\" transform=\"scale(.015625)\" d=\"m3122 3366v-538q-244 135-489 202t-495 67q-560 0-870-355-309-354-309-995t309-996q310-354 870-354 250 0 495 67t489 202v-532q-241-112-499-168-257-57-548-57-791 0-1257 497-465 497-465 1341 0 856 470 1346 471 491 1290 491 265 0 518-55 253-54 491-163z\"/></defs><use xlink:href=\"#DejaVuSans-63\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(80.622 101.88) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/><path id=\"DejaVuSans-39\" transform=\"scale(.015625)\" d=\"m703 97v575q238-113 481-172 244-59 479-59 625 0 954 420 330 420 377 1277-181-269-460-413-278-144-615-144-700 0-1108 423-408 424-408 1159 0 718 425 1152 425 435 1131 435 810 0 1236-621 427-620 427-1801 0-1103-524-1761-523-658-1407-658-238 0-482 47-243 47-506 141zm1256 1978q425 0 673 290 249 291 249 798 0 503-249 795-248 292-673 292t-673-292-248-795q0-507 248-798 248-290 673-290z\"/></defs><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-39\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-31\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(81.988 89.705) scale(.13 -.13)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-52\" transform=\"scale(.015625)\" d=\"m2841 2188q203-69 395-294t386-619l641-1275h-679l-596 1197q-232 469-449 622t-592 153h-688v-1972h-631v4666h1425q800 0 1194-335 394-334 394-1009 0-441-205-732-205-290-595-402zm-1582 1959v-1656h794q456 0 689 211t233 620-233 617-689 208h-794z\"/><path id=\"DejaVuSans-59\" transform=\"scale(.015625)\" d=\"m-13 4666h679l1293-1919 1285 1919h678l-1650-2444v-2222h-634v2222l-1651 2444z\"/></defs><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><path d=\"m135.88 50.309v-12.052\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m129.86 44.283h12.052\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(170.79 55.53) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/><path id=\"DejaVuSans-35\" transform=\"scale(.015625)\" d=\"m691 4666h2478v-532h-1900v-1143q137 47 274 70 138 23 276 23 781 0 1237-428 457-428 457-1159 0-753-469-1171-469-417-1322-417-294 0-599 50-304 50-629 150v635q281-153 581-228t634-75q541 0 856 284 316 284 316 772 0 487-316 771-315 285-856 285-253 0-505-56-251-56-513-175v2344z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-37\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-38\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-35\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(174.7 43.351) scale(.13 -.13)\" fill=\"#ffffff\"><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><path d=\"m228.59 50.309v-12.052\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><path d=\"m222.56 44.283h12.052\" clip-path=\"url(#p88131df891)\" fill=\"none\" stroke=\"#ffffff\" stroke-linecap=\"square\" stroke-width=\"2\"/><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(266.04 55.53) scale(.08 -.08)\" fill=\"#ffffff\"><defs><path id=\"DejaVuSans-33\" transform=\"scale(.015625)\" d=\"m2597 2516q453-97 707-404 255-306 255-756 0-690-475-1069-475-378-1350-378-293 0-604 58t-642 174v609q262-153 574-231 313-78 654-78 593 0 904 234t311 681q0 413-289 645-289 233-804 233h-544v519h569q465 0 712 186t247 536q0 359-255 551-254 193-729 193-260 0-557-57-297-56-653-174v562q360 100 674 150t592 50q719 0 1137-327 419-326 419-882 0-388-222-655t-631-370z\"/><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-32\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/></g></g><g clip-path=\"url(#p88131df891)\"><g transform=\"translate(267.4 43.351) scale(.13 -.13)\" fill=\"#ffffff\"><use transform=\"translate(0 .09375)\" xlink:href=\"#DejaVuSans-52\"/><use transform=\"translate(70.439 -16.312) scale(.7)\" xlink:href=\"#DejaVuSans-59\"/></g></g><defs><clipPath id=\"p88131df891\"><rect x=\"7.2\" y=\"7.2\" width=\"298.34\" height=\"157.6\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 538.128x284.278 with 1 Axes>"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1650,17 +1914,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 49,
    "id": "fe0fbe7a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<qiskit.circuit.instructionset.InstructionSet at 0x1432bb3d0>"
+       "<qiskit.circuit.instructionset.InstructionSet at 0x1367007c0>"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1680,7 +1944,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 50,
    "id": "b0ebf1ea",
    "metadata": {},
    "outputs": [
@@ -1694,13 +1958,13 @@
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"319.97pt\" version=\"1.1\" viewBox=\"0 0 451.81 319.97\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 319.97h451.81v-319.97h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 284.4h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"mb8faa953ad\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"107.277386\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb8faa953ad\"/><g transform=\"translate(107.86 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"249.31375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb8faa953ad\"/><g transform=\"translate(249.9 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"391.350114\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb8faa953ad\"/><g transform=\"translate(391.93 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><path d=\"m54.014 284.4h390.6\" clip-path=\"url(#p598f054d57)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"m402c32f90f\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m402c32f90f\"/><g transform=\"translate(24.749 289.72) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 216.82h390.6\" clip-path=\"url(#p598f054d57)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"216.816\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m402c32f90f\"/><g transform=\"translate(24.749 222.13) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/></g><path d=\"m54.014 149.23h390.6\" clip-path=\"url(#p598f054d57)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"149.232\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m402c32f90f\"/><g transform=\"translate(24.749 154.55) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 81.648h390.6\" clip-path=\"url(#p598f054d57)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"81.648\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m402c32f90f\"/><g transform=\"translate(24.749 86.967) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-33\" transform=\"scale(.015625)\" d=\"m2597 2516q453-97 707-404 255-306 255-756 0-690-475-1069-475-378-1350-378-293 0-604 58t-642 174v609q262-153 574-231 313-78 654-78 593 0 904 234t311 681q0 413-289 645-289 233-804 233h-544v519h569q465 0 712 186t247 536q0 359-255 551-254 193-729 193-260 0-557-57-297-56-653-174v562q360 100 674 150t592 50q719 0 1137-327 419-326 419-882 0-388-222-655t-631-370z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/></g><path d=\"m54.014 14.064h390.6\" clip-path=\"url(#p598f054d57)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"14.064\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m402c32f90f\"/><g transform=\"translate(24.749 19.383) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><g transform=\"translate(17.838 188.56) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 284.4h71.018v-217.8h-71.018z\" clip-path=\"url(#p598f054d57)\" fill=\"#648fff\"/><path d=\"m213.8 284.4h71.018v-227.04h-71.018z\" clip-path=\"url(#p598f054d57)\" fill=\"#648fff\"/><path d=\"m355.84 284.4h71.018v-231h-71.018z\" clip-path=\"url(#p598f054d57)\" fill=\"#648fff\"/><path d=\"m54.014 284.4v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 284.4h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(92.963 53.63) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-32\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-32\"/></g><g transform=\"translate(235 43.928) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-33\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-36\"/></g><g transform=\"translate(377.04 39.77) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-34\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-32\"/></g><defs><clipPath id=\"p598f054d57\"><rect x=\"54.014\" y=\"7.2\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"319.97pt\" version=\"1.1\" viewBox=\"0 0 451.81 319.97\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 319.97h451.81v-319.97h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 284.4h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"m32087c806e\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"107.277386\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m32087c806e\"/><g transform=\"translate(107.86 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"249.31375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m32087c806e\"/><g transform=\"translate(249.9 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"391.350114\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m32087c806e\"/><g transform=\"translate(391.93 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><path d=\"m54.014 284.4h390.6\" clip-path=\"url(#p9d21516403)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"m40a9dd2c76\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m40a9dd2c76\"/><g transform=\"translate(24.749 289.72) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 220.98h390.6\" clip-path=\"url(#p9d21516403)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"220.983378\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m40a9dd2c76\"/><g transform=\"translate(24.749 226.3) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/></g><path d=\"m54.014 157.57h390.6\" clip-path=\"url(#p9d21516403)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"157.566756\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m40a9dd2c76\"/><g transform=\"translate(24.749 162.89) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 94.15h390.6\" clip-path=\"url(#p9d21516403)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"94.150134\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m40a9dd2c76\"/><g transform=\"translate(24.749 99.469) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-33\" transform=\"scale(.015625)\" d=\"m2597 2516q453-97 707-404 255-306 255-756 0-690-475-1069-475-378-1350-378-293 0-604 58t-642 174v609q262-153 574-231 313-78 654-78 593 0 904 234t311 681q0 413-289 645-289 233-804 233h-544v519h569q465 0 712 186t247 536q0 359-255 551-254 193-729 193-260 0-557-57-297-56-653-174v562q360 100 674 150t592 50q719 0 1137-327 419-326 419-882 0-388-222-655t-631-370z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/></g><path d=\"m54.014 30.734h390.6\" clip-path=\"url(#p9d21516403)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"30.733512\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m40a9dd2c76\"/><g transform=\"translate(24.749 36.052) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><g transform=\"translate(17.838 188.56) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 284.4h71.018v-207.47h-71.018z\" clip-path=\"url(#p9d21516403)\" fill=\"#648fff\"/><path d=\"m213.8 284.4h71.018v-195.7h-71.018z\" clip-path=\"url(#p9d21516403)\" fill=\"#648fff\"/><path d=\"m355.84 284.4h71.018v-231h-71.018z\" clip-path=\"url(#p9d21516403)\" fill=\"#648fff\"/><path d=\"m54.014 284.4v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 284.4h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(92.963 64.48) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-32\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-37\"/></g><g transform=\"translate(235 76.836) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-39\" transform=\"scale(.015625)\" d=\"m703 97v575q238-113 481-172 244-59 479-59 625 0 954 420 330 420 377 1277-181-269-460-413-278-144-615-144-700 0-1108 423-408 424-408 1159 0 718 425 1152 425 435 1131 435 810 0 1236-621 427-620 427-1801 0-1103-524-1761-523-658-1407-658-238 0-482 47-243 47-506 141zm1256 1978q425 0 673 290 249 291 249 798 0 503-249 795-248 292-673 292t-673-292-248-795q0-507 248-798 248-290 673-290z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-30\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-39\"/></g><g transform=\"translate(377.04 39.77) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-33\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-34\"/></g><defs><clipPath id=\"p9d21516403\"><rect x=\"54.014\" y=\"7.2\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 700x500 with 1 Axes>"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1711,6 +1975,21 @@
     "print('Results for z measurements:')\n",
     "counts = backend.run(qc_charlie.compose(meas_zz)).result().get_counts()\n",
     "plot_histogram(counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "3ba6f813",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...the qubits never both output 0...\"\n",
+    "assert '00' not in counts.keys()"
    ]
   },
   {
@@ -1725,7 +2004,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 52,
    "id": "3dc83a1e",
    "metadata": {},
    "outputs": [
@@ -1739,13 +2018,13 @@
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"323.95pt\" version=\"1.1\" viewBox=\"0 0 451.81 323.95\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 323.95h451.81v-323.95h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 288.37h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"md1f48a4585\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"107.277386\" y=\"288.371967\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#md1f48a4585\"/><g transform=\"translate(107.86 315.75) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"249.31375\" y=\"288.371967\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#md1f48a4585\"/><g transform=\"translate(249.9 315.75) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"391.350114\" y=\"288.371967\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#md1f48a4585\"/><g transform=\"translate(391.93 315.75) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 288.37h390.6\" clip-path=\"url(#pa39fab0920)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"m8001e43ff2\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"288.371967\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m8001e43ff2\"/><g transform=\"translate(24.749 293.69) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 219.41h390.6\" clip-path=\"url(#pa39fab0920)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"219.408702\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m8001e43ff2\"/><g transform=\"translate(24.749 224.73) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 150.45h390.6\" clip-path=\"url(#pa39fab0920)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"150.445437\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m8001e43ff2\"/><g transform=\"translate(24.749 155.76) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><path d=\"m54.014 81.482h390.6\" clip-path=\"url(#pa39fab0920)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"81.482172\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m8001e43ff2\"/><g transform=\"translate(24.749 86.801) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/></g><path d=\"m54.014 12.519h390.6\" clip-path=\"url(#pa39fab0920)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"12.518906\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m8001e43ff2\"/><g transform=\"translate(24.749 17.838) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(17.838 192.53) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 288.37h71.018v-55.898h-71.018z\" clip-path=\"url(#pa39fab0920)\" fill=\"#648fff\"/><path d=\"m213.8 288.37h71.018v-57.918h-71.018z\" clip-path=\"url(#pa39fab0920)\" fill=\"#648fff\"/><path d=\"m355.84 288.37h71.018v-231h-71.018z\" clip-path=\"url(#pa39fab0920)\" fill=\"#648fff\"/><path d=\"m54.014 288.37v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 288.37h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(92.963 227.6) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-32\"/></g><g transform=\"translate(235 225.48) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(377.04 43.742) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-30\"/></g><defs><clipPath id=\"pa39fab0920\"><rect x=\"54.014\" y=\"11.172\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"319.97pt\" version=\"1.1\" viewBox=\"0 0 451.81 319.97\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 319.97h451.81v-319.97h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 284.4h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"m4e5718c930\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"107.277386\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m4e5718c930\"/><g transform=\"translate(107.86 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"249.31375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m4e5718c930\"/><g transform=\"translate(249.9 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"391.350114\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m4e5718c930\"/><g transform=\"translate(391.93 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 284.4h390.6\" clip-path=\"url(#p953b1f782f)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"m6f1a73248d\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m6f1a73248d\"/><g transform=\"translate(24.749 289.72) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 216.62h390.6\" clip-path=\"url(#p953b1f782f)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"216.62235\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m6f1a73248d\"/><g transform=\"translate(24.749 221.94) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 148.84h390.6\" clip-path=\"url(#p953b1f782f)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"148.844699\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m6f1a73248d\"/><g transform=\"translate(24.749 154.16) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><path d=\"m54.014 81.067h390.6\" clip-path=\"url(#p953b1f782f)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"81.067049\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m6f1a73248d\"/><g transform=\"translate(24.749 86.386) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/></g><path d=\"m54.014 13.289h390.6\" clip-path=\"url(#p953b1f782f)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"13.289398\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m6f1a73248d\"/><g transform=\"translate(24.749 18.608) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(17.838 188.56) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 284.4h71.018v-49.642h-71.018z\" clip-path=\"url(#p953b1f782f)\" fill=\"#648fff\"/><path d=\"m213.8 284.4h71.018v-58.246h-71.018z\" clip-path=\"url(#p953b1f782f)\" fill=\"#648fff\"/><path d=\"m355.84 284.4h71.018v-231h-71.018z\" clip-path=\"url(#p953b1f782f)\" fill=\"#648fff\"/><path d=\"m54.014 284.4v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 284.4h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(92.963 230.2) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-34\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-36\"/></g><g transform=\"translate(235 221.16) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-32\"/></g><g transform=\"translate(377.04 39.77) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-38\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-32\"/></g><defs><clipPath id=\"p953b1f782f\"><rect x=\"54.014\" y=\"7.2\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 700x500 with 1 Axes>"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1761,6 +2040,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "54e12807",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...the qubits never both output 1...\"\n",
+    "assert '11' not in counts.keys()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "cf1070b3",
    "metadata": {},
@@ -1770,7 +2064,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 54,
    "id": "3892d57c",
    "metadata": {},
    "outputs": [
@@ -1784,13 +2078,13 @@
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"320.77pt\" version=\"1.1\" viewBox=\"0 0 451.81 320.77\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 320.77h451.81v-320.77h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 285.19h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"m64a9fa7c14\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"107.277386\" y=\"285.192105\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m64a9fa7c14\"/><g transform=\"translate(107.86 312.57) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"249.31375\" y=\"285.192105\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m64a9fa7c14\"/><g transform=\"translate(249.9 312.57) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"391.350114\" y=\"285.192105\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m64a9fa7c14\"/><g transform=\"translate(391.93 312.57) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 285.19h390.6\" clip-path=\"url(#pd7877f9837)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"mf83181a229\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"285.192105\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf83181a229\"/><g transform=\"translate(24.749 290.51) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 217.02h390.6\" clip-path=\"url(#pd7877f9837)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"217.023805\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf83181a229\"/><g transform=\"translate(24.749 222.34) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 148.86h390.6\" clip-path=\"url(#pd7877f9837)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"148.855506\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf83181a229\"/><g transform=\"translate(24.749 154.17) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><path d=\"m54.014 80.687h390.6\" clip-path=\"url(#pd7877f9837)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"80.687206\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf83181a229\"/><g transform=\"translate(24.749 86.006) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/></g><path d=\"m54.014 12.519h390.6\" clip-path=\"url(#pd7877f9837)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"12.518906\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf83181a229\"/><g transform=\"translate(24.749 17.838) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(17.838 189.35) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 285.19h71.018v-60.246h-71.018z\" clip-path=\"url(#pd7877f9837)\" fill=\"#648fff\"/><path d=\"m213.8 285.19h71.018v-231h-71.018z\" clip-path=\"url(#pd7877f9837)\" fill=\"#648fff\"/><path d=\"m355.84 285.19h71.018v-49.595h-71.018z\" clip-path=\"url(#pd7877f9837)\" fill=\"#648fff\"/><path d=\"m54.014 285.19v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 285.19h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(92.963 219.85) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-37\"/></g><g transform=\"translate(235 40.562) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(377.04 231.04) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-34\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-36\"/></g><defs><clipPath id=\"pd7877f9837\"><rect x=\"54.014\" y=\"7.9921\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"319.97pt\" version=\"1.1\" viewBox=\"0 0 451.81 319.97\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 319.97h451.81v-319.97h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 284.4h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"m395216718b\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"107.277386\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m395216718b\"/><g transform=\"translate(107.86 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"249.31375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m395216718b\"/><g transform=\"translate(249.9 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"391.350114\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m395216718b\"/><g transform=\"translate(391.93 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 284.4h390.6\" clip-path=\"url(#p6b38fe9f45)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"mb51f205479\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb51f205479\"/><g transform=\"translate(24.749 289.72) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 214.93h390.6\" clip-path=\"url(#p6b38fe9f45)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"214.930396\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb51f205479\"/><g transform=\"translate(24.749 220.25) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 145.46h390.6\" clip-path=\"url(#p6b38fe9f45)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"145.460793\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb51f205479\"/><g transform=\"translate(24.749 150.78) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><path d=\"m54.014 75.991h390.6\" clip-path=\"url(#p6b38fe9f45)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"75.991189\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mb51f205479\"/><g transform=\"translate(24.749 81.31) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/></g><g transform=\"translate(17.838 188.56) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 284.4h71.018v-55.63h-71.018z\" clip-path=\"url(#p6b38fe9f45)\" fill=\"#648fff\"/><path d=\"m213.8 284.4h71.018v-231h-71.018z\" clip-path=\"url(#p6b38fe9f45)\" fill=\"#648fff\"/><path d=\"m355.84 284.4h71.018v-60.718h-71.018z\" clip-path=\"url(#p6b38fe9f45)\" fill=\"#648fff\"/><path d=\"m54.014 284.4v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 284.4h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(92.963 223.91) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-30\"/></g><g transform=\"translate(235 39.77) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-35\" transform=\"scale(.015625)\" d=\"m691 4666h2478v-532h-1900v-1143q137 47 274 70 138 23 276 23 781 0 1237-428 457-428 457-1159 0-753-469-1171-469-417-1322-417-294 0-599 50-304 50-629 150v635q281-153 581-228t634-75q541 0 856 284 316 284 316 772 0 487-316 771-315 285-856 285-253 0-505-56-251-56-513-175v2344z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-35\"/></g><g transform=\"translate(377.04 218.57) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-31\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-35\"/></g><defs><clipPath id=\"p6b38fe9f45\"><rect x=\"54.014\" y=\"7.2\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 700x500 with 1 Axes>"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 54,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1803,6 +2097,21 @@
     "print('Results for an x and a z measurement:')\n",
     "counts = backend.run(qc_charlie.compose(meas_xz)).result().get_counts()\n",
     "plot_histogram(counts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "22970b5d",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"...the qubits never both output 1. The same is true when...\"\n",
+    "assert '11' not in counts.keys()"
    ]
   },
   {
@@ -1824,7 +2133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 56,
    "id": "8005eb57",
    "metadata": {},
    "outputs": [
@@ -1838,13 +2147,13 @@
     {
      "data": {
       "image/svg+xml": [
-       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"319.97pt\" version=\"1.1\" viewBox=\"0 0 451.81 319.97\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 319.97h451.81v-319.97h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 284.4h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"mfc98dd0858\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"97.131932\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mfc98dd0858\"/><g transform=\"translate(97.716 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"198.586477\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mfc98dd0858\"/><g transform=\"translate(199.17 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"300.041023\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mfc98dd0858\"/><g transform=\"translate(300.62 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"401.495568\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mfc98dd0858\"/><g transform=\"translate(402.08 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><path d=\"m54.014 284.4h390.6\" clip-path=\"url(#p3f17022cd5)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"mf3361fc8da\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf3361fc8da\"/><g transform=\"translate(24.749 289.72) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 223.44h390.6\" clip-path=\"url(#p3f17022cd5)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"223.435052\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf3361fc8da\"/><g transform=\"translate(24.749 228.75) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 162.47h390.6\" clip-path=\"url(#p3f17022cd5)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"162.470103\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf3361fc8da\"/><g transform=\"translate(24.749 167.79) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><path d=\"m54.014 101.51h390.6\" clip-path=\"url(#p3f17022cd5)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"101.505155\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf3361fc8da\"/><g transform=\"translate(24.749 106.82) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/></g><path d=\"m54.014 40.54h390.6\" clip-path=\"url(#p3f17022cd5)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"40.540206\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#mf3361fc8da\"/><g transform=\"translate(24.749 45.859) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(17.838 188.56) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 284.4h50.727v-231h-50.727z\" clip-path=\"url(#p3f17022cd5)\" fill=\"#648fff\"/><path d=\"m173.22 284.4h50.727v-23.517h-50.727z\" clip-path=\"url(#p3f17022cd5)\" fill=\"#648fff\"/><path d=\"m274.68 284.4h50.727v-26.196h-50.727z\" clip-path=\"url(#p3f17022cd5)\" fill=\"#648fff\"/><path d=\"m376.13 284.4h50.727v-24.112h-50.727z\" clip-path=\"url(#p3f17022cd5)\" fill=\"#648fff\"/><path d=\"m54.014 284.4v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 284.4h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(82.818 39.77) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/><path id=\"DejaVuSans-35\" transform=\"scale(.015625)\" d=\"m691 4666h2478v-532h-1900v-1143q137 47 274 70 138 23 276 23 781 0 1237-428 457-428 457-1159 0-753-469-1171-469-417-1322-417-294 0-599 50-304 50-629 150v635q281-153 581-228t634-75q541 0 856 284 316 284 316 772 0 487-316 771-315 285-856 285-253 0-505-56-251-56-513-175v2344z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-37\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-35\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(184.27 257.63) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-37\"/></g><g transform=\"translate(285.73 254.81) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-38\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-36\"/></g><g transform=\"translate(387.18 257) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-39\" transform=\"scale(.015625)\" d=\"m703 97v575q238-113 481-172 244-59 479-59 625 0 954 420 330 420 377 1277-181-269-460-413-278-144-615-144-700 0-1108 423-408 424-408 1159 0 718 425 1152 425 435 1131 435 810 0 1236-621 427-620 427-1801 0-1103-524-1761-523-658-1407-658-238 0-482 47-243 47-506 141zm1256 1978q425 0 673 290 249 291 249 798 0 503-249 795-248 292-673 292t-673-292-248-795q0-507 248-798 248-290 673-290z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-39\"/></g><defs><clipPath id=\"p3f17022cd5\"><rect x=\"54.014\" y=\"7.2\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
+       "<?xml version=\"1.0\" encoding=\"UTF-8\"?><!DOCTYPE svg  PUBLIC '-//W3C//DTD SVG 1.1//EN'  'http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd'><svg width=\"451.81pt\" height=\"319.97pt\" version=\"1.1\" viewBox=\"0 0 451.81 319.97\" xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\"><defs><style type=\"text/css\">*{stroke-linejoin: round; stroke-linecap: butt}</style></defs><path d=\"m0 319.97h451.81v-319.97h-451.81z\" fill=\"#ffffff\"/><path d=\"m54.014 284.4h390.6v-277.2h-390.6z\" fill=\"#ffffff\"/><defs><path id=\"m5cf94661e7\" d=\"m0 0v3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"97.131932\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m5cf94661e7\"/><g transform=\"translate(97.716 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-30\" transform=\"scale(.015625)\" d=\"m2034 4250q-487 0-733-480-245-479-245-1442 0-959 245-1439 246-480 733-480 491 0 736 480 246 480 246 1439 0 963-246 1442-245 480-736 480zm0 500q785 0 1199-621 414-620 414-1801 0-1178-414-1799-414-620-1199-620-784 0-1198 620-414 621-414 1799 0 1181 414 1801 414 621 1198 621z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"198.586477\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m5cf94661e7\"/><g transform=\"translate(199.17 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-31\" transform=\"scale(.015625)\" d=\"m794 531h1031v3560l-1122-225v575l1116 225h631v-4135h1031v-531h-2687v531z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><use x=\"300.041023\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m5cf94661e7\"/><g transform=\"translate(300.62 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-30\"/></g><use x=\"401.495568\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m5cf94661e7\"/><g transform=\"translate(402.08 311.78) rotate(-70) scale(.14 -.14)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-31\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-31\"/></g><path d=\"m54.014 284.4h390.6\" clip-path=\"url(#p36f411b0bf)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><defs><path id=\"m512ef7ccaf\" d=\"m0 0h-3.5\" stroke=\"#343a3f\" stroke-width=\".8\"/></defs><use x=\"54.01375\" y=\"284.4\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m512ef7ccaf\"/><g transform=\"translate(24.749 289.72) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-2e\" transform=\"scale(.015625)\" d=\"m684 794h660v-794h-660v794z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/></g><path d=\"m54.014 224.29h390.6\" clip-path=\"url(#p36f411b0bf)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"224.287166\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m512ef7ccaf\"/><g transform=\"translate(24.749 229.61) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-32\" transform=\"scale(.015625)\" d=\"m1228 531h2203v-531h-2962v531q359 372 979 998 621 627 780 809 303 340 423 576 121 236 121 464 0 372-261 606-261 235-680 235-297 0-627-103-329-103-704-313v638q381 153 712 231 332 78 607 78 725 0 1156-363 431-362 431-968 0-288-108-546-107-257-392-607-78-91-497-524-418-433-1181-1211z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-32\"/></g><path d=\"m54.014 164.17h390.6\" clip-path=\"url(#p36f411b0bf)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"164.174333\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m512ef7ccaf\"/><g transform=\"translate(24.749 169.49) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-34\" transform=\"scale(.015625)\" d=\"m2419 4116-1594-2491h1594v2491zm-166 550h794v-3041h666v-525h-666v-1100h-628v1100h-2106v609l1940 2957z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-34\"/></g><path d=\"m54.014 104.06h390.6\" clip-path=\"url(#p36f411b0bf)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"104.061499\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m512ef7ccaf\"/><g transform=\"translate(24.749 109.38) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-36\" transform=\"scale(.015625)\" d=\"m2113 2584q-425 0-674-291-248-290-248-796 0-503 248-796 249-292 674-292t673 292q248 293 248 796 0 506-248 796-248 291-673 291zm1253 1979v-575q-238 112-480 171-242 60-480 60-625 0-955-422-329-422-376-1275 184 272 462 417 279 145 613 145 703 0 1111-427 408-426 408-1160 0-719-425-1154-425-434-1131-434-810 0-1238 620-428 621-428 1799 0 1106 525 1764t1409 658q238 0 480-47t505-140z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-36\"/></g><path d=\"m54.014 43.949h390.6\" clip-path=\"url(#p36f411b0bf)\" fill=\"none\" stroke=\"#dde1e6\" stroke-dasharray=\"2.96,1.28\" stroke-width=\".8\"/><use x=\"54.01375\" y=\"43.948666\" fill=\"#343a3f\" stroke=\"#343a3f\" stroke-width=\".8\" xlink:href=\"#m512ef7ccaf\"/><g transform=\"translate(24.749 49.268) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-38\" transform=\"scale(.015625)\" d=\"m2034 2216q-450 0-708-241-257-241-257-662 0-422 257-663 258-241 708-241t709 242q260 243 260 662 0 421-258 662-257 241-711 241zm-631 268q-406 100-633 378-226 279-226 679 0 559 398 884 399 325 1092 325 697 0 1094-325t397-884q0-400-227-679-226-278-629-378 456-106 710-416 255-309 255-755 0-679-414-1042-414-362-1186-362-771 0-1186 362-414 363-414 1042 0 446 256 755 257 310 713 416zm-231 997q0-362 226-565 227-203 636-203 407 0 636 203 230 203 230 565 0 363-230 566-229 203-636 203-409 0-636-203-226-203-226-566z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-38\"/></g><g transform=\"translate(17.838 188.56) rotate(-90) scale(.14 -.14)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-50\" transform=\"scale(.015625)\" d=\"m1259 4147v-1753h794q441 0 681 228 241 228 241 650 0 419-241 647-240 228-681 228h-794zm-631 519h1425q785 0 1186-355 402-355 402-1039 0-691-402-1044-401-353-1186-353h-794v-1875h-631v4666z\"/><path id=\"DejaVuSans-72\" transform=\"scale(.015625)\" d=\"m2631 2963q-97 56-211 82-114 27-251 27-488 0-749-317t-261-911v-1844h-578v3500h578v-544q182 319 472 473 291 155 707 155 59 0 131-8 72-7 159-23l3-590z\"/><path id=\"DejaVuSans-6f\" transform=\"scale(.015625)\" d=\"m1959 3097q-462 0-731-361t-269-989 267-989q268-361 733-361 460 0 728 362 269 363 269 988 0 622-269 986-268 364-728 364zm0 487q750 0 1178-488 429-487 429-1349 0-859-429-1349-428-489-1178-489-753 0-1180 489-426 490-426 1349 0 862 426 1349 427 488 1180 488z\"/><path id=\"DejaVuSans-62\" transform=\"scale(.015625)\" d=\"m3116 1747q0 634-261 995t-717 361q-457 0-718-361t-261-995 261-995 718-361q456 0 717 361t261 995zm-1957 1222q182 312 458 463 277 152 661 152 638 0 1036-506 399-506 399-1331t-399-1332q-398-506-1036-506-384 0-661 152-276 152-458 464v-525h-578v4863h578v-1894z\"/><path id=\"DejaVuSans-61\" transform=\"scale(.015625)\" d=\"m2194 1759q-697 0-966-159t-269-544q0-306 202-486 202-179 548-179 479 0 768 339t289 901v128h-572zm1147 238v-1997h-575v531q-197-318-491-470t-719-152q-537 0-855 302-317 302-317 808 0 590 395 890 396 300 1180 300h807v57q0 397-261 614t-733 217q-300 0-585-72-284-72-546-216v532q315 122 612 182 297 61 578 61 760 0 1135-394 375-393 375-1193z\"/><path id=\"DejaVuSans-69\" transform=\"scale(.015625)\" d=\"m603 3500h575v-3500h-575v3500zm0 1363h575v-729h-575v729z\"/><path id=\"DejaVuSans-6c\" transform=\"scale(.015625)\" d=\"m603 4863h575v-4863h-575v4863z\"/><path id=\"DejaVuSans-74\" transform=\"scale(.015625)\" d=\"m1172 4494v-994h1184v-447h-1184v-1900q0-428 117-550t477-122h590v-481h-590q-666 0-919 248-253 249-253 905v1900h-422v447h422v994h578z\"/><path id=\"DejaVuSans-65\" transform=\"scale(.015625)\" d=\"m3597 1894v-281h-2644q38-594 358-905t892-311q331 0 642 81t618 244v-544q-310-131-635-200t-659-69q-838 0-1327 487-489 488-489 1320 0 859 464 1363 464 505 1252 505 706 0 1117-455 411-454 411-1235zm-575 169q-6 471-264 752-258 282-683 282-481 0-770-272t-333-766l2050 4z\"/><path id=\"DejaVuSans-73\" transform=\"scale(.015625)\" d=\"m2834 3397v-544q-243 125-506 187-262 63-544 63-428 0-642-131t-214-394q0-200 153-314t616-217l197-44q612-131 870-370t258-667q0-488-386-773-386-284-1061-284-281 0-586 55t-642 164v594q319-166 628-249 309-82 613-82 406 0 624 139 219 139 219 392 0 234-158 359-157 125-692 241l-200 47q-534 112-772 345-237 233-237 639 0 494 350 762 350 269 994 269 318 0 599-47 282-46 519-140z\"/></defs><use xlink:href=\"#DejaVuSans-50\"/><use x=\"58.552734\" xlink:href=\"#DejaVuSans-72\"/><use x=\"97.416016\" xlink:href=\"#DejaVuSans-6f\"/><use x=\"158.597656\" xlink:href=\"#DejaVuSans-62\"/><use x=\"222.074219\" xlink:href=\"#DejaVuSans-61\"/><use x=\"283.353516\" xlink:href=\"#DejaVuSans-62\"/><use x=\"346.830078\" xlink:href=\"#DejaVuSans-69\"/><use x=\"374.613281\" xlink:href=\"#DejaVuSans-6c\"/><use x=\"402.396484\" xlink:href=\"#DejaVuSans-69\"/><use x=\"430.179688\" xlink:href=\"#DejaVuSans-74\"/><use x=\"469.388672\" xlink:href=\"#DejaVuSans-69\"/><use x=\"497.171875\" xlink:href=\"#DejaVuSans-65\"/><use x=\"558.695312\" xlink:href=\"#DejaVuSans-73\"/></g><path d=\"m71.768 284.4h50.727v-231h-50.727z\" clip-path=\"url(#p36f411b0bf)\" fill=\"#648fff\"/><path d=\"m173.22 284.4h50.727v-23.775h-50.727z\" clip-path=\"url(#p36f411b0bf)\" fill=\"#648fff\"/><path d=\"m274.68 284.4h50.727v-22.014h-50.727z\" clip-path=\"url(#p36f411b0bf)\" fill=\"#648fff\"/><path d=\"m376.13 284.4h50.727v-23.775h-50.727z\" clip-path=\"url(#p36f411b0bf)\" fill=\"#648fff\"/><path d=\"m54.014 284.4v-277.2\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><path d=\"m54.014 284.4h390.6\" fill=\"none\" stroke=\"#343a3f\" stroke-linecap=\"square\" stroke-width=\".8\"/><g transform=\"translate(82.818 39.77) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-37\" transform=\"scale(.015625)\" d=\"m525 4666h3e3v-269l-1694-4397h-659l1594 4134h-2241v532z\"/><path id=\"DejaVuSans-39\" transform=\"scale(.015625)\" d=\"m703 97v575q238-113 481-172 244-59 479-59 625 0 954 420 330 420 377 1277-181-269-460-413-278-144-615-144-700 0-1108 423-408 424-408 1159 0 718 425 1152 425 435 1131 435 810 0 1236-621 427-620 427-1801 0-1103-524-1761-523-658-1407-658-238 0-482 47-243 47-506 141zm1256 1978q425 0 673 290 249 291 249 798 0 503-249 795-248 292-673 292t-673-292-248-795q0-507 248-798 248-290 673-290z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-37\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-36\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-39\"/></g><g transform=\"translate(184.27 257.36) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-39\"/></g><g transform=\"translate(285.73 259.21) scale(.1 -.1)\" fill=\"#343a3f\"><defs><path id=\"DejaVuSans-33\" transform=\"scale(.015625)\" d=\"m2597 2516q453-97 707-404 255-306 255-756 0-690-475-1069-475-378-1350-378-293 0-604 58t-642 174v609q262-153 574-231 313-78 654-78 593 0 904 234t311 681q0 413-289 645-289 233-804 233h-544v519h569q465 0 712 186t247 536q0 359-255 551-254 193-729 193-260 0-557-57-297-56-653-174v562q360 100 674 150t592 50q719 0 1137-327 419-326 419-882 0-388-222-655t-631-370z\"/></defs><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-33\"/></g><g transform=\"translate(387.18 257.36) scale(.1 -.1)\" fill=\"#343a3f\"><use xlink:href=\"#DejaVuSans-30\"/><use x=\"63.623047\" xlink:href=\"#DejaVuSans-2e\"/><use x=\"95.410156\" xlink:href=\"#DejaVuSans-30\"/><use x=\"159.033203\" xlink:href=\"#DejaVuSans-37\"/><use x=\"222.65625\" xlink:href=\"#DejaVuSans-39\"/></g><defs><clipPath id=\"p36f411b0bf\"><rect x=\"54.014\" y=\"7.2\" width=\"390.6\" height=\"277.2\"/></clipPath></defs></svg>"
       ],
       "text/plain": [
        "<Figure size 700x500 with 1 Axes>"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 56,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1860,6 +2169,21 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "c5401ac9",
+   "metadata": {
+    "tags": [
+     "sanity-check"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# \"The 11 result is not likely, but it is certainly not impossible.\"\n",
+    "assert '11' in counts.keys()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "b3cf90b9",
    "metadata": {},
@@ -1867,6 +2191,31 @@
     "They would not! The `11` result is not likely, but it is certainly not impossible.\n",
     "\n",
     "The results of qubits are not well-defined before measurement. Though this might seem like it means that qubits are more random that classical variables, it is not always a negative quality. It also means that restrictions applied to classical variables do not always apply to qubits, and that quantum correlations can have properties that would be impossible classically. These unique correlations are one of the signature properties of entangled states."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "30e93541",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.21.2</td></tr><tr><td><code>qiskit-aer</code></td><td>0.10.4</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.19.2</td></tr><tr><td><code>qiskit</code></td><td>0.37.2</td></tr><tr><td><code>qiskit-nature</code></td><td>0.4.1</td></tr><tr><td><code>qiskit-finance</code></td><td>0.3.2</td></tr><tr><td><code>qiskit-optimization</code></td><td>0.4.0</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.4.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.8.13</td></tr><tr><td>Python compiler</td><td>Clang 13.1.6 (clang-1316.0.21.2.5)</td></tr><tr><td>Python build</td><td>default, Aug 29 2022 05:17:23</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>32.0</td></tr><tr><td colspan='2'>Tue Sep 20 16:21:45 2022 BST</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# pylint: disable=unused-import\n",
+    "import qiskit.tools.jupyter\n",
+    "%qiskit_version_table"
    ]
   }
  ],

--- a/scripts/content_checks/README.md
+++ b/scripts/content_checks/README.md
@@ -82,5 +82,21 @@ the notebooks that hold the textbook content.
   optionally fail on warnings if passed `--fail-on-warning`. On PRs, this
   script runs on any changed notebooks.
 
+  Notebooks can include sanity checks on cell outputs; tagging these cells with
+  `sanity-check` stops them appearing on the website. These cells should
+  contain some kind of simple `assert` statement that checks the output of
+  recent cells matches what's written in the text. This helps us catch
+  unexpected code changes (e.g. from package updates, bugfixes in other parts
+  of the notebook, or unlikely random samples). When adding a sanity check
+  cell, you should include the quote from the main text that you're checking
+  against. For example:
+  ```
+  # "...the output of the last cell is 0."
+  assert _ == 0
+  ```
+  In Jupyter notebooks, `_` stores the last cell output. You can also use
+  `Out[x]` to refer to specific cell outputs (assume all notebooks are run from
+  top to bottom).
+
 - `tools.py`: Shared logic (e.g. argument parsing) used by scripts in this
   folder.


### PR DESCRIPTION
When creating notebooks, the writing should comment on the code outputs. When these notebooks are updated later on (maybe due to package updates or bugfixes), the code outputs can change, and the person updating the notebooks might not (and shouldn't really have to) know what a reasonable output looks like. E.g. for circuit results, is `516` close enough to `541`?. This PR adds the ability for writers to add 'sanity check' cells to notebooks that check the code outputs match what's written in the markdown cells.

## Changes

- Added logic in the converter to filter out code cells with `sanity-check` tags. (d033092b7f7edca7e28ec551cfdd94e6430efcc2)
- Added `_` and `Out` to Pylint builtins. (eef03b658d077e027b51e94b1ed77c89f00f2fe6)
- Added some sanity check cells to `intro/entangled-states`. I chose this notebook as I recognised an occurrance of code/prose mismatch (see screenshot). This notebook was also relatively simple acts as a good example for other contributors. (6d93e73e7148ae617b1ac71ffca37b87ef82956a)
  ![Screenshot 2022-09-20 at 17 01 34](https://user-images.githubusercontent.com/36071638/191307908-792316ac-3f1b-47e3-97d4-210937cac4c9.png)
- Also noticed that the CI runs all the notebooks instead of just the changed notebooks, hopefully have fixed that too. (20362b94d5d17a7def5eafc7e6dfaaafb995a329)
