### PR TITLE
v-html to resolve escape sequences

### DIFF
--- a/frontend/vue/components/common/AppCta.vue
+++ b/frontend/vue/components/common/AppCta.vue
@@ -8,9 +8,7 @@
     ]"
     v-bind="$attrs"
   >
-    <span class="app-cta__content">
-      {{ label }}
-    </span>
+    <span class="app-cta__content" v-html="label"></span>
     <component
       :is="iconPerLinkType"
       class="app-cta__icon"


### PR DESCRIPTION
## Changes

<!--
  Required.

  Briefly describe the changes introduced by this pull request.
  Also link relevant issues with the "closes", "fixes" or "resolves" keywords,
  and add co-authors where appropriate with the "co-authored-by" keyword.

  Example:
  Implemented the functionality to update the user's name.
  Closes #42
  Co-authored-by: @octocat
-->

This change partially resolves issue  #1539. The issue mentions the escape sequences in both next/prev buttons at the bottom of course pages and in the browser page title. This just fixes the next/prev buttons as of right now.

## Implementation details

<!--
  Optional.

  If useful for the code review, describe implementation details and, if
  necessary, why a certain approach was chosen.

  Example:
  Changes are introduced to the controller and the database model. UI changes
  are not in the scope of this PR.
-->
Used v-html. Change was made in AppCta.vue.

<!--## How to read this PR


  Optional.

  If useful for the code review, add some guidance for how to read this PR,
  including links to preview builds.

  Example:
  Please start reviewing the changes to the controller files. Then check the
  changes to the database files. This way, you will have more context about the
  changes made to the database model.
  You can test the changes at https://preview-42.example.com/profile/update
-->

## Screenshots

<!--
  Optional.

  If relevant (e.g. UI changes are introduced), add screenshots or videos
  depicting the changes. Ideally, showing the before and after situations.
-->

![image](https://user-images.githubusercontent.com/66499864/191412450-cbfe19ae-e46c-4639-8254-ba01c8bea6ab.png)

