### PR TITLE
Make [KO],[ES], [PT] translations publishable

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ domain: learn.qiskit.org
 # privacyURL: /policies
 # googleAnalytics: UA-XXX-XXX
 # banner: (c) Mathigon Ltd
-locales: [en, ja]
+locales: [en, ja, es, ko, pt]
 
 search:
   enabled: false

--- a/translations/es/toc.yaml
+++ b/translations/es/toc.yaml
@@ -1,0 +1,97 @@
+- title: Estados cuánticos y Qubits
+  url: /ch-states
+  sections:
+    - id: introduction
+      uuid: afcc559e-b519-11ec-b909-0242ac120002
+      url: /ch-states/introduction
+    - id: the-atoms-of-computation
+      uuid: b31c20ee-b519-11ec-b909-0242ac120002
+      url: /ch-states/atoms-computation
+    - id: representing-qubit-states
+      uuid: b81717ca-b519-11ec-b909-0242ac120002
+      url: /ch-states/representing-qubit-states
+    - id: single-qubit-gates
+      uuid: bd4334a4-b519-11ec-b909-0242ac120002
+      url: /ch-states/single-qubit-gates
+    - id: the-case-for-quantum-computers
+      uuid: c0bbff62-b519-11ec-b909-0242ac120002
+      url: /ch-states/case-for-quantum
+
+
+- title: Múltiples Qubits y entrelazamiento
+  url: /ch-gates
+  sections:
+    - id: introduction
+      uuid: c50f4c90-b519-11ec-b909-0242ac120002
+      url: /ch-gates/introduction
+    - id: multiple-qubits-and-entangled-states
+      uuid: c7cfe502-b519-11ec-b909-0242ac120002
+      url: /ch-gates/multiple-qubits-entangled-states
+    - id: basic-circuit-identities
+      uuid: ce8ce75a-b519-11ec-b909-0242ac120002
+      url: /ch-gates/more-circuit-identities
+    - id: proving-universality
+      uuid: d15d3548-b519-11ec-b909-0242ac120002
+      url: /ch-gates/proving-universality
+    - id: classical-computation-on-a-quantum-computer
+      uuid: d4f6e424-b519-11ec-b909-0242ac120002
+      url: /ch-gates/oracles
+
+
+- title: Protocolos cuánticos y algoritmos cuánticos
+  url: /ch-algorithms
+  sections:
+    - id: quantum-circuits
+      uuid: d90cbfb6-b519-11ec-b909-0242ac120002
+      url: /ch-algorithms/defining-quantum-circuits
+    - id: deutsch-jozsa-algorithm
+      uuid: dc9d3aa2-b519-11ec-b909-0242ac120002
+      url: /ch-algorithms/deutsch-jozsa
+    - id: bernstein-vazirani-algorithm
+      uuid: df6e5a40-b519-11ec-b909-0242ac120002
+      url: /ch-algorithms/bernstein-vazirani
+
+
+- title: Algoritmos cuánticos para aplicaciones
+  url: /ch-applications
+  sections:
+    - id: simulating-molecules-using-vqe
+      uuid: 041df288-b51a-11ec-b909-0242ac120002
+      url: /ch-applications/vqe-molecules
+    - id: solving-combinatorial-optimization-problems-using-qaoa
+      uuid: 06ff7ada-b51a-11ec-b909-0242ac120002
+      url: /ch-applications/qaoa
+
+
+- title: Laboratorios de computación cuántica
+  url: /ch-labs
+  sections:
+    - id: lab-9-quantum-simulation-as-a-search-algorithm
+      uuid: 59a076f4-b51a-11ec-b909-0242ac120002
+      url: /ch-labs/Lab09_QuantumSimulationSearchAlgorithm
+
+
+- title: Juegos y demostraciones
+  url: /ch-demos
+  sections:
+    - id: estimating-pi-pi-using-quantum-phase-estimation-algorithm
+      uuid: 69b9707c-b51a-11ec-b909-0242ac120002
+      url: /ch-demos/piday-code
+
+
+- title: Algoritmos cuánticos
+  url: /algorithms
+  type: learning-path
+  sections:
+    - id: phase-kickback
+      uuid: 976e9da6-6c33-4e2f-b7eb-f9588f700f07
+      url: /algorithms/phase-kickback
+
+
+- title: Introducción a la Computación Cuántica
+  url: /introduction
+  type: learning-path
+  sections:
+    - uuid: bdb1d662-e0f6-428a-8830-befe6b47f320
+      id: why-quantum-computing
+      url: /intro/why-quantum-computing

--- a/translations/ko/toc.yaml
+++ b/translations/ko/toc.yaml
@@ -1,0 +1,64 @@
+- title: 양자 상태 및 큐비트
+  url: /ch-states
+  sections:
+    - id: introduction
+      uuid: afcc559e-b519-11ec-b909-0242ac120002
+      url: /ch-states/introduction
+    - id: the-atoms-of-computation
+      uuid: b31c20ee-b519-11ec-b909-0242ac120002
+      url: /ch-states/atoms-computation
+    - id: representing-qubit-states
+      uuid: b81717ca-b519-11ec-b909-0242ac120002
+      url: /ch-states/representing-qubit-states
+    - id: the-case-for-quantum-computers
+      uuid: c0bbff62-b519-11ec-b909-0242ac120002
+      url: /ch-states/case-for-quantum
+
+
+- title: 다중 큐비트 및 얽힘
+  url: /ch-gates
+  sections:
+    - id: multiple-qubits-and-entangled-states
+      uuid: c7cfe502-b519-11ec-b909-0242ac120002
+      url: /ch-gates/multiple-qubits-entangled-states
+    - id: basic-circuit-identities
+      uuid: ce8ce75a-b519-11ec-b909-0242ac120002
+      url: /ch-gates/more-circuit-identities
+
+
+- title: 양자 프로토콜 및 양자 알고리즘
+  url: /ch-algorithms
+  sections:
+    - id: bernstein-vazirani-algorithm
+      uuid: df6e5a40-b519-11ec-b909-0242ac120002
+      url: /ch-algorithms/bernstein-vazirani
+
+
+- title: 양자 알고리즘
+  url: /algorithms
+  type: learning-path
+  sections:
+    - id: phase-kickback
+      uuid: 976e9da6-6c33-4e2f-b7eb-f9588f700f07
+      url: /algorithms/phase-kickback
+
+
+- title: 양자 컴퓨팅 소개
+  url: /introduction
+  type: learning-path
+  sections:
+    - uuid: bdb1d662-e0f6-428a-8830-befe6b47f320
+      id: why-quantum-computing
+      url: /intro/why-quantum-computing
+    - id: what-is-quantum
+      uuid: 7c765036-aebc-11ec-b909-0242ac120002
+      url: /intro/what-is-quantum
+    - id: describing-quantum-computers
+      uuid: 9260a554-aebc-11ec-b909-0242ac120002
+      url: /intro/describing-quantum-computers
+    - id: grovers-search-algorithm
+      uuid: a2e6f7a2-aebc-11ec-b909-0242ac120002
+      url: /intro/grover-intro
+    - id: project
+      uuid: e25c3f90-aebd-11ec-b909-0242ac120002
+      url: /intro/project

--- a/translations/pt/toc.yaml
+++ b/translations/pt/toc.yaml
@@ -1,0 +1,54 @@
+- title: Pré-requisitos
+  url: /ch-prerequisites
+  sections:
+    - id: environment-setup-guide-to-work-with-qiskit-textbook
+      uuid: a5a86ddc-b519-11ec-b909-0242ac120002
+      url: /ch-prerequisites/setting-the-environment
+    - id: introduction-to-python-and-jupyter-notebooks
+      uuid: a9f5ea68-b519-11ec-b909-0242ac120002
+      url: /ch-prerequisites/python-and-jupyter-notebooks
+
+
+- title: Algoritmos Quânticos
+  url: /algorithms
+  type: learning-path
+  sections:
+    - id: phase-kickback
+      uuid: 976e9da6-6c33-4e2f-b7eb-f9588f700f07
+      url: /algorithms/phase-kickback
+
+
+- title: Introdução à computação quântica
+  url: /introduction
+  type: learning-path
+  sections:
+    - uuid: bdb1d662-e0f6-428a-8830-befe6b47f320
+      id: why-quantum-computing
+      url: /intro/why-quantum-computing
+    - id: the-atoms-of-computation
+      uuid: 37ef477e-ab8d-11ec-b909-0242ac120002
+      url: /intro/atoms-of-computation
+    - id: what-is-quantum
+      uuid: 7c765036-aebc-11ec-b909-0242ac120002
+      url: /intro/what-is-quantum
+    - id: describing-quantum-computers
+      uuid: 9260a554-aebc-11ec-b909-0242ac120002
+      url: /intro/describing-quantum-computers
+    - id: entangled-states
+      uuid: 98aa9032-aebc-11ec-b909-0242ac120002
+      url: /intro/entangled-states
+    - id: visualizing-entanglement
+      uuid: 9e8ceb9e-aebc-11ec-b909-0242ac120002
+      url: /intro/visualizing-entanglement
+    - id: project
+      uuid: e25c3f90-aebd-11ec-b909-0242ac120002
+      url: /intro/project
+
+
+- title: Aprendizado de máquina quântico
+  url: /machine-learning
+  type: learning-path
+  sections:
+    - id: data-encoding
+      uuid: 1d09af66-b51b-11ec-b909-0242ac120002
+      url: /quantum-machine-learning/encoding


### PR DESCRIPTION
Made Korean, Spanish and Portuguese translations publishable: 

- updated `config.yaml` to include the three languages in the build;
- added toc.yaml for each of the three languages. Section names are Google-translated.

**NB** Bengali and Chinese can not be added until [#1602](https://github.com/Qiskit/platypus/issues/1602) is resolved.