### PR TITLE
Handle code in headings

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -204,8 +204,8 @@ def handle_hero_image(hero_image_syntax):
 def handle_heading(heading_syntax, in_block, suffix, section, is_problem_set=False):
     """Increase header level and compute level, title, and id"""
     header, title = heading_syntax.split(" ", 1)
+    title = handle_inline_code(title)
     level = header.count("#")
-    is_problem_set = is_problem_set
     if in_block:
         return None, None, title, f"#{heading_syntax}\n"
     else:


### PR DESCRIPTION
## Changes

When writing, we use the monospace font to make it clearer we're talking about Python functions / classes etc.

This PR adds some logic to the converter to parse code in headings so we can use the monospace font in the headings.

## Screenshots

Example from the quantum 301 course

![Screenshot 2022-10-05 at 16 48 42](https://user-images.githubusercontent.com/36071638/194104536-0e4eb0d7-dd6e-4b82-82bd-d382be4298e1.png)
