### PR TITLE
Revert "Add basics course to mega menu"

### DIFF
--- a/frontend/vue/components/constants/megaMenuLinks.ts
+++ b/frontend/vue/components/constants/megaMenuLinks.ts
@@ -1,7 +1,6 @@
 import { NavLink } from './../../../constants/menuLinks'
 
 const wholeSection = 'whole-section'
-const sectionBasicsCourse = 'basics-course'
 const sectionIntroductionCourse = 'introduction-course'
 const sectionQMLCourse = 'quantum-machine-learning'
 const sectionPrerequisites = 'prerequisites'
@@ -17,7 +16,6 @@ const sectionTutorials = 'tutorials'
 const sectionSummerSchool = 'summer-schools'
 const sectionProblemSets = 'problem-sets'
 
-const pathBasicsCourse = '/course/basics'
 const pathIntroductionCourse = '/course/introduction'
 const pathQuantumMachineLearning = '/course/machine-learning'
 const pathPrerequisites = '/course/ch-prerequisites'
@@ -37,39 +35,6 @@ const tutorialsBaseUrl = 'https://qiskit.org/documentation/tutorials'
 type MegaDropdownMenuGroup = {
   title: NavLink,
   content: NavLink[]
-}
-
-const BASICS_COURSE: MegaDropdownMenuGroup = {
-  title: {
-    label: 'Basics of quantum information',
-    url: `${pathBasicsCourse}`,
-    segment: {
-      cta: wholeSection, location: sectionBasicsCourse
-    }
-  },
-  content: [
-    {
-      label: 'Single systems',
-      url: `${pathBasicsCourse}/single-systems`,
-      segment: {
-        cta: 'single_systems', location: sectionBasicsCourse
-      }
-    },
-    {
-      label: 'Multiple systems',
-      url: `${pathBasicsCourse}/multiple-systems`,
-      segment: {
-        cta: 'multiple_systems', location: sectionBasicsCourse
-      }
-    },
-    {
-      label: 'Circuits, protocols, and games',
-      url: `${pathBasicsCourse}/circuits-protocols-games`,
-      segment: {
-        cta: 'circuits_protocols_and_games', location: sectionBasicsCourse
-      }
-    }
-  ]
 }
 
 const INTRODUCTION_COURSE: MegaDropdownMenuGroup = {
@@ -1461,7 +1426,6 @@ type MegaDropdownMenuContent = MegaDropdownMenuSection[]
 const COURSES_SECTION: MegaDropdownMenuSection = {
   title: 'Courses',
   content: [
-    BASICS_COURSE,
     INTRODUCTION_COURSE,
     QML_COURSE
   ]


### PR DESCRIPTION
Reverts Qiskit/platypus#1643

Sorry, I didn't mention in #1643 that we should wait until the page is officially released before publishing. We can either revert and re-merge, or ignore this and instead wait to push this change to the release branch.