### PR TITLE
Add Syllabi duplication functionality

### DIFF
--- a/frontend/vue/components/Syllabus/SyllabusForm.vue
+++ b/frontend/vue/components/Syllabus/SyllabusForm.vue
@@ -57,13 +57,13 @@ import 'carbon-web-components/es/components/tabs/tabs.js'
 import 'carbon-web-components/es/components/tabs/tab.js'
 import AppCta from '../common/AppCta.vue'
 import BasicLink from '../common/BasicLink.vue'
+import { Syllabus, SyllabusCourse, emptySyllabus, getActiveSyllabus } from '../../../ts/syllabus'
 import SyllabusFormCourseInfo from './SyllabusFormCourseInfo.vue'
 import SyllabusFormModule from './SyllabusFormModule.vue'
 import SyllabusInlineNotification from './SyllabusInlineNotification.vue'
-import { Syllabus, SyllabusCourse, emptySyllabus, getActiveSyllabus } from '../../../ts/syllabus'
 
 interface DeletedCourse {
-  index: number, 
+  index: number,
   course: SyllabusCourse
 }
 
@@ -104,11 +104,16 @@ export default defineComponent({
       syllabus: emptySyllabus()
     }
   },
-  mounted() {
+  mounted () {
     const activeSyllabus = getActiveSyllabus()
     if (activeSyllabus) {
       this.syllabus = activeSyllabus
       this.editMode = true
+
+      if (activeSyllabus.name.startsWith('Copy of')) {
+        this.syllabus.name = ''
+        this.syllabus.instructor = ''
+      }
     }
     this.syllabusInfoChanged(this.syllabus)
   },
@@ -123,7 +128,7 @@ export default defineComponent({
     removeContentBlock (course: SyllabusCourse) {
       const index = this.syllabus.courseList.indexOf(course)
       this.lastDeletedCourse = { index, course }
-      this.syllabus.courseList.splice(index, 1);
+      this.syllabus.courseList.splice(index, 1)
     },
     closeNotification () {
       this.lastDeletedCourse = undefined
@@ -133,8 +138,8 @@ export default defineComponent({
       const csrfToken = { _csrf: window.csrfToken }
       fetch(url, {
         method: 'POST', // *GET, POST, PUT, DELETE, etc.
-        headers: {'Content-Type': 'application/json' },
-        body: JSON.stringify({ 
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
           ...csrfToken,
           ...this.syllabus
         })
@@ -155,7 +160,7 @@ export default defineComponent({
       }
 
       const index = this.lastDeletedCourse.index
-      this.syllabus.courseList.splice(index, 0, this.lastDeletedCourse.course);
+      this.syllabus.courseList.splice(index, 0, this.lastDeletedCourse.course)
       this.lastDeletedCourse = undefined
     },
     syllabusInfoChanged (data: Syllabus) {

--- a/frontend/vue/components/Syllabus/SyllabusFormCourseInfo.vue
+++ b/frontend/vue/components/Syllabus/SyllabusFormCourseInfo.vue
@@ -9,6 +9,7 @@
         placeholder="Please enter the syllabus name"
         label-text="Syllabus name *"
         color-scheme="light"
+        autofocus
         :required="true"
         @input="updateFormInfo"
       />

--- a/frontend/vue/components/Syllabus/SyllabusFormCourseInfo.vue
+++ b/frontend/vue/components/Syllabus/SyllabusFormCourseInfo.vue
@@ -224,6 +224,7 @@ export default defineComponent({
   }
 
   &__input-field {
+    --cds-focus: #{$border-color-secondary};
     padding-bottom: $spacing-05;
 
     &:not(:last-child) {

--- a/frontend/vue/components/Syllabus/SyllabusLayout.vue
+++ b/frontend/vue/components/Syllabus/SyllabusLayout.vue
@@ -40,7 +40,6 @@ export default defineComponent({
   data () {
     return {
       syllabus: undefined as Syllabus | undefined,
-      // userIsLoggedIn: false,
       sectionList: ACCOUNT_MENU_LINKS,
       syllabusParentPath: '/account/classroom'
     }

--- a/frontend/vue/components/Syllabus/SyllabusLayout.vue
+++ b/frontend/vue/components/Syllabus/SyllabusLayout.vue
@@ -71,7 +71,6 @@ export default defineComponent({
   }
 
   &__container {
-    @include contained();
     margin-left: 0;
     padding: $spacing-07 $spacing-08;
   }

--- a/frontend/vue/components/Syllabus/SyllabusLayout.vue
+++ b/frontend/vue/components/Syllabus/SyllabusLayout.vue
@@ -13,7 +13,7 @@
           {{ syllabus.name }}
         </template>
       </UserAccountSectionHeader>
-      <SyllabusView :syllabus="syllabus" />
+      <SyllabusView :syllabus="syllabus" :user-is-logged-in="userIsLoggedIn" />
     </div>
   </div>
 </template>
@@ -40,9 +40,17 @@ export default defineComponent({
   data () {
     return {
       syllabus: undefined as Syllabus | undefined,
-      userIsLoggedIn: false,
+      // userIsLoggedIn: false,
       sectionList: ACCOUNT_MENU_LINKS,
       syllabusParentPath: '/account/classroom'
+    }
+  },
+  computed: {
+    userIsLoggedIn () {
+      if (this.firstName !== '' || this.lastName !== '') {
+        return true
+      }
+      return false
     }
   },
   mounted () {

--- a/frontend/vue/components/Syllabus/SyllabusView.vue
+++ b/frontend/vue/components/Syllabus/SyllabusView.vue
@@ -1,5 +1,13 @@
 <template>
   <section class="syllabus-view">
+    <bx-btn
+      class="syllabus-view__duplicate"
+      kind="ghost"
+      @click="duplicateAction"
+    >
+      <span class="syllabus-view__duplicate__label">Duplicate syllabus</span>
+      <Download16 class="syllabus-view__duplicate__icon" />
+    </bx-btn>
     <h2 class="syllabus-view__general-info-title">
       General Information
     </h2>
@@ -37,18 +45,20 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue-demi'
+import Download16 from '@carbon/icons-vue/es/download/16'
 import BasicLink from '../common/BasicLink.vue'
 import ColumnFlowGrid from '../common/ColumnFlowGrid.vue'
-import SyllabusGeneralInformation from './SyllabusGeneralInformation.vue'
 import { Syllabus } from '../../../ts/syllabus'
 import { getCourseList, Section, Course } from '../../../ts/courses'
+import SyllabusGeneralInformation from './SyllabusGeneralInformation.vue'
 
 export default defineComponent({
   name: 'SyllabusView',
   components: {
     SyllabusGeneralInformation,
     BasicLink,
-    ColumnFlowGrid
+    ColumnFlowGrid,
+    Download16
   },
   props: {
     syllabus: {
@@ -59,15 +69,15 @@ export default defineComponent({
   },
   data () {
     return {
-      sectionList: [] as Section[],
+      sectionList: [] as Section[]
     }
   },
   mounted () {
     getCourseList().then((courses) => {
       const availableCourses = courses.filter(course => course.type !== 'docs')
       this.sectionList = availableCourses.reduce((sectionList: Section[], course: Course) => {
-          return sectionList.concat(course.sections)
-        }, [] as Section[])
+        return sectionList.concat(course.sections)
+      }, [] as Section[])
     })
   },
   methods: {
@@ -76,6 +86,9 @@ export default defineComponent({
     },
     getNameById (id: string) {
       return this.sectionList.find((section: Section) => section.uuid === id)?.title
+    },
+    duplicateAction () {
+      console.log('duplicate')
     }
   }
 })
@@ -87,10 +100,39 @@ export default defineComponent({
 @import '~/../scss/variables/colors.scss';
 
 .syllabus-view {
+  position: relative;
   background-color: $background-color-lighter;
-  padding: $spacing-06 $spacing-05;
+  padding: $spacing-05;
   user-select: text;
   cursor: auto;
+  @include mq($until: medium) {
+    padding: $spacing-10 $spacing-05 $spacing-06 $spacing-05;
+  }
+
+  &__duplicate {
+    position: absolute;
+    top: 0;
+    right: 0;
+
+    @include mq($until: medium) {
+      right: initial;
+      left: 0;
+    }
+
+    &::part(button) {
+      --cds-link-01: #{$purple-70};
+      --cds-hover-primary-text: #{$purple-70};
+      &:focus,
+      &:hover {
+        background-color: $cool-gray-20;
+      }
+    }
+
+    &__label {
+      display: block;
+      padding-right: $spacing-05;
+    }
+  }
 
   &__general-info-title {
     @include type-style('expressive-heading-03', $fluid: true);

--- a/frontend/vue/components/Syllabus/SyllabusView.vue
+++ b/frontend/vue/components/Syllabus/SyllabusView.vue
@@ -123,7 +123,7 @@ export default defineComponent({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           ...csrfToken,
-          ...this.syllabus
+          ...duplicatedSyllabus
         })
       }).then((res) => {
         if (res.status === 200) {

--- a/frontend/vue/components/Syllabus/SyllabusView.vue
+++ b/frontend/vue/components/Syllabus/SyllabusView.vue
@@ -112,7 +112,6 @@ export default defineComponent({
       const duplicatedSyllabus = this.syllabus
       duplicatedSyllabus.id = ''
       duplicatedSyllabus.code = ''
-      // duplicatedSyllabus.ownerList = []
       duplicatedSyllabus.name = `Copy of ${this.syllabus.name}`
 
       window.textbook.trackClickEvent('syllabus', `Duplicate syllabus: ${this.syllabus.name}`)


### PR DESCRIPTION
## Changes

Closes #1514 
Closes https://github.com/Qiskit/platypus/issues/1515

## Implementation details

- add Duplicate syllabus button
- add tooltip helper 
- use server redirects to bring users back to Syllabus, if they don't have an account
  - (given that `req.session` clears when a user auths through google, I had to use `res.cookie` so that the `returnTo` url param would save in the browser)

## Screenshots


https://user-images.githubusercontent.com/6276074/196808947-cd712e20-dcd2-44a5-8f69-b8c72e03db1a.mov

