### PR TITLE
feature(syllabusCard): add read-only prop

### DIFF
--- a/frontend/vue/components/UserAccount/SyllabusCard.vue
+++ b/frontend/vue/components/UserAccount/SyllabusCard.vue
@@ -6,6 +6,7 @@
     </div>
     <div class="syllabus-card__footer">
       <AppCta
+        v-if="!readOnly"
         class="syllabus-card__footer__cta syllabus-card__footer__cta-edit"
         :url="`/syllabus/edit/${syllabus.code}`"
         label="Edit Syllabus"
@@ -36,6 +37,11 @@ export default defineComponent({
       type: Object,
       required: false,
       default: ''
+    },
+    readOnly: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   }
 })


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/1655


## Implementation details

- adds an optional prop to the SyllabusCard so that if the syllabus is considered _read only_ (i.e. Community Syllabi), then it won't render the Edit button


## How to test
- locally, you can pass in the `read-only` attribute into the SyllabusCard, in the `ClassroomSection.vue` file. Visit the `/account/classroom` page to see the syllabi, and notice that the edit button is gone.
- note, when @mariacloehb adds the Community Syllabi, we'll be adding this read-only prop so that users don't think they can edit those

```html
<SyllabusCard
  v-for="syllabus in syllabi"
  :key="syllabus.id"
  :syllabus="syllabus"
  read-only
/>
```



## How to read this PR

- this is just one way to handle hiding the Edit button for Community Syllabi, but I'd be open to other ideas on how to conditionalize this

## Screenshots

![Screen Shot 2022-10-26 at 10 40 28 AM (2)](https://user-images.githubusercontent.com/6276074/198098618-f026c03e-aef9-4dad-b6d8-7dc7c801fd91.png)
