### PR TITLE
feature(curated-syllabi): verify ownership by user id

### DIFF
--- a/frontend/vue/components/UserAccount/ClassroomSection.vue
+++ b/frontend/vue/components/UserAccount/ClassroomSection.vue
@@ -43,6 +43,7 @@
           v-for="syllabus in syllabi"
           :key="syllabus.id"
           :syllabus="syllabus"
+          :user-id="userId"
         />
       </div>
     </section>
@@ -60,8 +61,9 @@
       <div class="classroom__section__syllabi-list">
         <SyllabusCard
           v-for="syllabus in communitySyllabi"
-          :key="syllabus.id"
+          :key="syllabus.code"
           :syllabus="syllabus"
+          :user-id="userId"
         />
       </div>
     </section>
@@ -82,6 +84,13 @@ export default defineComponent({
     AppCta,
     SyllabusCard
   },
+  props: {
+    userId: {
+      type: String,
+      required: true,
+      default: ''
+    }
+  },
   data () {
     return {
       syllabi: [] as Syllabus[],
@@ -98,19 +107,22 @@ export default defineComponent({
           name: 'Quantum Computing with Superconducting Qubits',
           instructor: 'Jay Gambetta',
           institution: 'IBM Quantum',
-          code: 'TRY-SW8'
+          code: 'TRY-SW8',
+          ownerList: ['community']
         },
         {
           name: 'Introduction to Quantum Algorithms',
           instructor: 'Peter Shor',
           institution: 'Masachussetts Institute of Technology',
-          code: 'CFH-KBT'
+          code: 'CFH-KBT',
+          ownerList: ['community']
         },
         {
           name: 'Preparing for the Qiskit developer certification exam',
           instructor: 'James L. Weaver',
           institution: 'IBM Quantum',
-          code: 'S9P-7GP'
+          code: 'S9P-7GP',
+          ownerList: ['community']
         }
       ]
     }

--- a/frontend/vue/components/UserAccount/ClassroomSection.vue
+++ b/frontend/vue/components/UserAccount/ClassroomSection.vue
@@ -87,7 +87,7 @@ export default defineComponent({
   props: {
     userId: {
       type: String,
-      required: true,
+      required: false,
       default: ''
     }
   },

--- a/frontend/vue/components/UserAccount/SyllabusCard.vue
+++ b/frontend/vue/components/UserAccount/SyllabusCard.vue
@@ -50,11 +50,7 @@ export default defineComponent({
     userIsOwner () {
       const currentSyllabus = JSON.parse(JSON.stringify(this.syllabus))
 
-      if (currentSyllabus?.ownerList.includes(this.userId)) {
-        return true
-      }
-      return false
-    }
+      return currentSyllabus?.ownerList.includes(this.userId)
   }
 })
 </script>

--- a/frontend/vue/components/UserAccount/SyllabusCard.vue
+++ b/frontend/vue/components/UserAccount/SyllabusCard.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="syllabus-card">
     <div class="syllabus-card__body">
-      <h4 class="syllabus-card__title">{{ syllabus.name }}</h4>
+      <h4 class="syllabus-card__title">
+        {{ syllabus.name }}
+      </h4>
       <SyllabusGeneralInformation class="syllabus-card__data" :syllabus="syllabus" />
     </div>
     <div class="syllabus-card__footer">
       <AppCta
+        v-if="userIsOwner"
         class="syllabus-card__footer__cta syllabus-card__footer__cta-edit"
         :url="`/syllabus/edit/${syllabus.code}`"
         label="Edit Syllabus"
@@ -35,7 +38,22 @@ export default defineComponent({
     syllabus: {
       type: Object,
       required: false,
+      default: () => { }
+    },
+    userId: {
+      type: String,
+      required: true,
       default: ''
+    }
+  },
+  computed: {
+    userIsOwner () {
+      const currentSyllabus = JSON.parse(JSON.stringify(this.syllabus))
+
+      if (currentSyllabus?.ownerList.includes(this.userId)) {
+        return true
+      }
+      return false
     }
   }
 })

--- a/frontend/vue/components/UserAccount/SyllabusCard.vue
+++ b/frontend/vue/components/UserAccount/SyllabusCard.vue
@@ -42,15 +42,16 @@ export default defineComponent({
     },
     userId: {
       type: String,
-      required: true,
+      required: false,
       default: ''
     }
   },
   computed: {
-    userIsOwner () {
+    userIsOwner ():boolean {
       const currentSyllabus = JSON.parse(JSON.stringify(this.syllabus))
 
       return currentSyllabus?.ownerList.includes(this.userId)
+    }
   }
 })
 </script>

--- a/frontend/vue/components/UserAccount/UserAccountLayout.vue
+++ b/frontend/vue/components/UserAccount/UserAccountLayout.vue
@@ -11,7 +11,7 @@
         <UserProgress />
       </div>
       <div v-else-if="activeSection === sectionList[1].url">
-        <ClassroomSection />
+        <ClassroomSection :user-id="userId" />
       </div>
       <div v-if="activeSection === sectionList[2].url">
         <AccountAdmin :first-name="firstName" :last-name="lastName" :email="email" />
@@ -42,7 +42,8 @@ export default defineComponent({
   props: {
     firstName: { type: String, required: false, default: '' },
     lastName: { type: String, required: false, default: '' },
-    email: { type: String, required: false, default: '' }
+    email: { type: String, required: false, default: '' },
+    userId: { type: String, required: true, default: '' }
   },
   data () {
     return {

--- a/server/app.ts
+++ b/server/app.ts
@@ -113,7 +113,8 @@ const getAccountData = async (req: Request, res: Response) => {
   const loggedInUser = {
     firstName: req.user.firstName,
     lastName: req.user.lastName,
-    email: req.user.email
+    email: req.user.email,
+    userId: req.user.id
   }
 
   const progressData = await getUserProgressData(req)

--- a/server/templates/userAccount.pug
+++ b/server/templates/userAccount.pug
@@ -10,7 +10,7 @@ html(lang=lang dir=dir)
       q-the-menu
 
     .body
-      q-user-account-layout(first-name=userData.firstName, last-name=userData.lastName email=userData.email)
+      q-user-account-layout(first-name=userData.firstName, last-name=userData.lastName email=userData.email user-id=userData.userId)
 
     script(type="application/json")#translations!= translationsJSON
     script(type="application/json")#privacyPolicy!= privacyPolicyMD


### PR DESCRIPTION
## Changes

Closes https://github.com/Qiskit/platypus/issues/1655

## Implementation details

- with this change, the `SyllabusCard` will only render the edit button if the current logged in user id is found in the syllabus `ownerList`
- added a mock owner to the community syllabi using `ownerList: ['community']` (needed to check against logged in `user.id`)



## How to read this PR
- log in locally and navigate to the `account/classroom` route
- please review how `user.id` is passed down to the `SyllabusCard` component 
- review the computed property `userIsOwner`
- try duplicating a syllabus and seeing what happens

## Notes
(in a separate issue, we'll be adding community syllabi to the "local database")

## Screenshots

https://user-images.githubusercontent.com/6276074/198581916-f8042ec2-910b-40cf-9873-7c23873dd5c7.mov


