### PR TITLE
feature(curated-syllabi): update redirect

### DIFF
--- a/frontend/vue/components/Syllabus/SyllabusForm.vue
+++ b/frontend/vue/components/Syllabus/SyllabusForm.vue
@@ -109,11 +109,6 @@ export default defineComponent({
     if (activeSyllabus) {
       this.syllabus = activeSyllabus
       this.editMode = true
-
-      if (activeSyllabus.name.startsWith('Copy of')) {
-        this.syllabus.name = ''
-        this.syllabus.instructor = ''
-      }
     }
     this.syllabusInfoChanged(this.syllabus)
   },

--- a/frontend/vue/components/Syllabus/SyllabusView.vue
+++ b/frontend/vue/components/Syllabus/SyllabusView.vue
@@ -127,7 +127,9 @@ export default defineComponent({
         })
       }).then((res) => {
         if (res.status === 200) {
-          window.location.href = '/account/classroom'
+          res.json().then((jsonResult: Syllabus) => {
+            window.location.href = `/syllabus/edit/${jsonResult.code}`
+          })
         } else {
           // TODO: Manage this error (and improve backend feedback)
           console.error(res)


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/1684


## Implementation details

- when a user copies a syllabus, they are redirected to the `syllabus/edit/<SYLLABUS-CODE>` form
  - updated the form so the Syllabus name persists with the "Copy of [Original syllabus name]" convention
  - keeps the first field (Syllabus name) in focus, so the user has an indication of what they just duplicated
  


## Screenshots


https://user-images.githubusercontent.com/6276074/200942415-38c491fe-1bfb-4cc2-891f-d79edb0bb851.mov


