### PR TITLE
Fix of a small typo: bits -> qubits

### DIFF
--- a/notebooks/intro/visualizing-entanglement.ipynb
+++ b/notebooks/intro/visualizing-entanglement.ipynb
@@ -581,7 +581,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When writing quantum programs, we have to set up our qubits and bits before we can use them. This is done by the function below. It defines a register of two bits, and assigns them as our variables `A` and `B`. It then sets up a register of two bits to receive the outputs, and assigns them as `a` and `b`.\n",
+    "When writing quantum programs, we have to set up our qubits and bits before we can use them. This is done by the function below. It defines a register of two qubits, and assigns them as our variables `A` and `B`. It then sets up a register of two bits to receive the outputs, and assigns them as `a` and `b`.\n",
     "\n",
     "Finally it uses these registers to set up an empty quantum program. This is called `qc`."
    ]


### PR DESCRIPTION
## Changes

I found and fixed a small typo where "bits" has been written in the text but from the corresponding code snippet it is clear that it should be "qubits".
