### PR TITLE
Handle markdown blockquotes

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -245,6 +245,7 @@ def handle_markdown_cell(cell, resources, cell_number, is_problem_set=False):
     markdown_lines = []
     lines = cell.source.splitlines()
     in_latex = False
+    in_blockquote = False
     in_block = False
     in_code = False
     headings = []
@@ -289,6 +290,16 @@ def handle_markdown_cell(cell, resources, cell_number, is_problem_set=False):
             else:
                 markdown_lines.append(line + "\n")
             continue
+
+        if in_blockquote:
+            if not line.startswith(">"):
+                in_blockquote = False
+                markdown_lines.append("</blockquote>\n")
+        if line.startswith(">"):
+            line = line.strip(">")
+            if not in_blockquote:
+                in_blockquote = True
+                markdown_lines.append("<blockquote>\n")
 
         line = handle_attachments(line, cell)
 

--- a/frontend/scss/custom.scss
+++ b/frontend/scss/custom.scss
@@ -38,6 +38,12 @@ button span.rangle {
   margin-left: 2em;
 }
 
+blockquote {
+  font-size: 0.875rem;
+  padding-left: $spacing-unit;
+  border-left: 4px solid $cool-gray-20;
+}
+
 /* Make youtube full width */
 .youtube-wrapper {
   position: relative;


### PR DESCRIPTION
At the moment, we have no way of handling markdown blockquotes (i.e. lines starting with `>`). This PR adds that functionality.

## Changes
 
- Added logic in the converter to recognise lines starting with `>` as block quotes, and to wrap them in `<blockquote>` tags.
- Added scss to indent these blocks slightly, and add a left margin (similar to GitHub & Jupyter notebook)

## Screenshots

The code below is from the multiple systems page of the basics course (see #1697):

```
For example, suppose that $\mathsf{X}$ and $\mathsf{Y}$ are bits, and consider an operation with the following description.

> If $\mathsf{X} = 1$, then perform a NOT operation on $\mathsf{Y}$, otherwise do nothing.

This is a deterministic operation known as a *controlled-NOT* operation, where $\mathsf{X}$ is the *control* bit that determines whether or not a NOT operation should be applied to the *target* bit $\mathsf{Y}$.
```

and renders like this:

![Screenshot 2022-11-28 at 14 00 26](https://user-images.githubusercontent.com/36071638/204311078-ec82fa8f-d8c9-49be-98cc-546fb1171ced.png)

previously, the content in the block quote did not appear at all.

## Other examples

This is how GitHub handles block quotes

> This is a block quote

Similarly in notebooks:

![Screenshot 2022-11-28 at 15 07 28](https://user-images.githubusercontent.com/36071638/204311611-36efcdcf-e370-4fc9-84dd-689c855443d8.png)

