### PR TITLE
Use 'uses-hardware' tag to check if cell requires api token

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -365,27 +365,31 @@ def handle_code_cell_output(cell_output):
     return None
 
 
-def handle_grader_metadata(cell_metada):
-    """Parse grader metadata and return code exercise widget syntax
+def handle_code_cell_metadata(cell_metada):
+    """Parse code cell metadata (including grader information) and return code
+    exercise widget syntax
     """
-    grader_attr = None
+    attr = ''
 
     if "grader_import" in cell_metada and "grader_function" in cell_metada:
         grader_import = cell_metada["grader_import"]
         grader_function = cell_metada["grader_function"]
-        grader_attr = f'grader-import="{grader_import}" grader-function="{grader_function}"'
+        attr = f'grader-import="{grader_import}" grader-function="{grader_function}"'
     elif "grader_id" in cell_metada and "grader_answer" in cell_metada:
         grader_id = cell_metada["grader_id"]
         grader_answer = cell_metada["grader_answer"]
-        grader_attr = f'grader-id="{grader_id}" grader-answer="{grader_answer}"'
+        attr = f'grader-id="{grader_id}" grader-answer="{grader_answer}"'
 
-    if grader_attr:
+    if attr:
         goal = cell_metada["goals"] if "goals" in cell_metada else None
 
         if goal is not None:
-            grader_attr = f"{grader_attr} goal=\"{goal[0].id}\""
+            attr = f"{attr} goal=\"{goal[0].id}\""
 
-    return f"q-code-exercise({grader_attr or ''})"
+    if 'tags' in cell_metada and 'uses-hardware' in cell_metada['tags']:
+        attr += ' uses-hardware="true" '
+
+    return f"q-code-exercise({attr})"
 
 
 def handle_code_cell(cell, resources):
@@ -403,11 +407,11 @@ def handle_code_cell(cell, resources):
     )
     formatted_source = re.sub(r'[\^]?\s*# pylint:.*', '', formatted_source)
 
-    grader_widget = handle_grader_metadata(cell.metadata)
+    widget_string = handle_code_cell_metadata(cell.metadata)
 
     code_lines = [
-        f"\n::: {grader_widget}\n",
-        "    pre.\n      ",
+        f"\n::: {widget_string}\n",
+        f"    pre.\n      ",
         formatted_source,
         "\n\n"
     ]

--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -384,7 +384,7 @@ def handle_code_cell_metadata(cell_metada):
         goal = cell_metada["goals"] if "goals" in cell_metada else None
 
         if goal is not None:
-            attr = f"{attr} goal=\"{goal[0].id}\""
+            attr += f" goal=\"{goal[0].id}\""
 
     if 'tags' in cell_metada and 'uses-hardware' in cell_metada['tags']:
         attr += ' uses-hardware="true" '

--- a/frontend/vue/components/CodeExercise/CodeExercise.vue
+++ b/frontend/vue/components/CodeExercise/CodeExercise.vue
@@ -23,11 +23,11 @@
     <div v-if="isApiTokenNeeded" class="code-exercise__api-token-info">
       <WarningIcon />
       <div>
-        This code is executed on real hardware using an IBM Quantum provider. Setup your API-token in
+        This code connects to, or relies on results from IBM Quantum. Add your API-token to
         <BasicLink url="/account/admin">
           your account
         </BasicLink>
-        to execute this code cell.
+        to run this cell.
       </div>
     </div>
     <CodeOutput
@@ -98,6 +98,11 @@ export default defineComponent({
       type: String,
       required: false,
       default: ''
+    },
+    usesHardware: {
+      type: Boolean,
+      required: false,
+      default: false
     }
   },
   data () {
@@ -107,7 +112,7 @@ export default defineComponent({
       isKernelBusy: false,
       isKernelReady: false,
       hideInitialOutput: false,
-      isApiTokenNeeded: false,
+      isApiTokenNeeded: this.usesHardware,
       id: 0
     }
   },
@@ -159,7 +164,7 @@ export default defineComponent({
       this.code = code
       const codeOutput: any = this.$refs.output
       codeOutput.needsApiToken(this.code).then((isNeeded: boolean) => {
-        this.isApiTokenNeeded = isNeeded
+        this.isApiTokenNeeded = isNeeded || this.usesHardware
       })
     },
     keyboardRun () {

--- a/frontend/vue/components/UtilityPanel/Scratchpad.vue
+++ b/frontend/vue/components/UtilityPanel/Scratchpad.vue
@@ -29,11 +29,11 @@
       <div v-if="isApiTokenNeeded" class="scratchpad__api-token-info">
         <WarningIcon />
         <div>
-          This code is executed on real hardware using an IBM Quantum provider. Setup your API-token in
+          This code looks like it connects to IBM Quantum. Add your API-token to
           <BasicLink url="/account/admin">
             your account
           </BasicLink>
-          to execute this code cell.
+          to run this cell.
         </div>
       </div>
       <CodeOutput


### PR DESCRIPTION
At the moment, we disable any code cells that contain '`IBMQ.`' as they probably connect to IBM Quantum, and can't run without an API token. This does not stop users from running cells further down the notebook that rely on results from IBM Quantum. Fortunately, most notebooks contain '`uses-hardware`' tags for cells that rely on results from IBM Quantum, this PR uses those tags to block more cells.

## Changes

- Modify converter to pass the `uses-hardware` tag through
- Modify the component to use this property to determine if a cell needs an API token
- Modify the messages to closer reflect the reason we've disabled the cell

## Screenshots
From [Deutsch-Jozsa algorithm page](https://learn.qiskit.org/course/ch-algorithms/deutsch-jozsa-algorithm#device) (left before, right after).
<div style="display: grid; grid-template-columns: 1fr 1fr;">
  <img src="https://user-images.githubusercontent.com/36071638/206696810-d97355f2-a126-4e19-8a35-cf7b8e467cae.png" width=400">
  <img src="https://user-images.githubusercontent.com/36071638/206698902-eb36a30d-cbe2-4364-85e2-b34b032e2f5a.png" width=400>
</div>

