### PR TITLE
Fix typos in entangled states page

### DIFF
--- a/notebooks/intro/entangled-states.ipynb
+++ b/notebooks/intro/entangled-states.ipynb
@@ -180,14 +180,14 @@
     "We'll use $|b a\\rangle$ to refer to product combined state of these, where $|a\\rangle$ represents the qubit on the right and $|b\\rangle$ is the one on the left. We can write this as:\n",
     "\n",
     "$$ \n",
-    "|b \\, a\\rangle = \\begin{bmatrix} b_0 a_0 \\\\ b_0 a_1 \\\\ b_1 a_0 \\\\ b_1 a_1 \\end{bmatrix}.\n",
+    "|b a\\rangle = \\begin{bmatrix} b_0 a_0 \\\\ b_0 a_1 \\\\ b_1 a_0 \\\\ b_1 a_1 \\end{bmatrix}.\n",
     "$$\n",
     "\n",
     "Again, these rules follow from standard probability rules: If we want to find the probability of two unrelated events occurring, we multiply their probabilities together. To extend this rule to quantum mechanics, we just switch out probabilities with amplitudes. So the amplitude of the state $|00\\rangle$ is the amplitude of qubit $a$ being $|0\\rangle$, multiplied by the amplitude of qubit $b$ being $|0\\rangle$.\n",
     "\n",
     "Let's check this works: Suppose both qubits are measured, what is the probability that the qubit on the right comes out `0`? This will be the sum of the probabilities for the two outcomes which have a `0` on the right, namely `00` and `10`,\n",
     "\n",
-    "$$ \\cssId{_pa0}{p_{|a\\rangle}(|0\\rangle)} = p_{|ab\\rangle}(|00\\rangle) + p_{|ab\\rangle}(|10\\rangle). $$\n",
+    "$$ \\cssId{_pa0}{p_{|a\\rangle}(|0\\rangle)} = p_{|ba\\rangle}(|00\\rangle) + p_{|ba\\rangle}(|10\\rangle). $$\n",
     "\n",
     "Now we can substitute in the calculations for these states given above and do simple algebra\n",
     "\n",
@@ -1088,7 +1088,7 @@
    "source": [
     "For a message `00`, the state created by these gates is $|\\Phi^+ \\rangle$. For the other messages we get other entangled states, know as $|\\Phi^- \\rangle$, $|\\Psi^+ \\rangle$ and $|\\Psi^- \\rangle$.\n",
     "\n",
-    "$$ \\mathtt{00} \\rightarrow |\\Phi^+ \\rangle = \\frac{1}{\\sqrt{2}}(|00\\rangle+|11\\rangle) \\\\ \\mathtt{01} \\rightarrow |\\Psi^+ \\rangle = \\frac{1}{\\sqrt{2}}(|01\\rangle+|10\\rangle) \\\\ \\mathtt{10} \\rightarrow |\\Phi^- \\rangle = \\frac{1}{\\sqrt{2}}(|00\\rangle-|11\\rangle) \\\\ \\mathtt{11} \\rightarrow |\\Psi^- \\rangle = \\frac{1}{\\sqrt{2}}(|01\\rangle-|10\\rangle)$$\n",
+    "$$ \\mathtt{00} \\rightarrow |\\Phi^+ \\rangle = \\frac{1}{\\sqrt{2}}(|00\\rangle+|11\\rangle) \\\\ \\mathtt{01} \\rightarrow |\\Psi^+ \\rangle = \\frac{1}{\\sqrt{2}}(|01\\rangle+|10\\rangle) \\\\ \\mathtt{10} \\rightarrow |\\Phi^- \\rangle = \\frac{1}{\\sqrt{2}}(|00\\rangle-|11\\rangle) \\\\ \\mathtt{11} \\rightarrow |\\Psi^- \\rangle = \\frac{1}{\\sqrt{2}}(|10\\rangle-|01\\rangle)$$\n",
     "\n",
     "When Bob receives these states he needs to disentangle them, by undoing the `h` and `cx`. Then he can measure and retrieve the message as before."
    ]
@@ -2190,7 +2190,7 @@
    "source": [
     "They would not! The `11` result is not likely, but it is certainly not impossible.\n",
     "\n",
-    "The results of qubits are not well-defined before measurement. Though this might seem like it means that qubits are more random that classical variables, it is not always a negative quality. It also means that restrictions applied to classical variables do not always apply to qubits, and that quantum correlations can have properties that would be impossible classically. These unique correlations are one of the signature properties of entangled states."
+    "The results of qubits are not well-defined before measurement. Though this might seem like it means that qubits are more random than classical variables, it is not always a negative quality. It also means that restrictions applied to classical variables do not always apply to qubits, and that quantum correlations can have properties that would be impossible classically. These unique correlations are one of the signature properties of entangled states."
    ]
   },
   {


### PR DESCRIPTION
## Changes

- Fixed typo with $|\Psi^-\rangle$ Bell state definition (fixes #1764)
- Fixed typos in qubit labels (and a small typo in the text) (fixes #1741)

See issues for details.
