### PR TITLE
Add install instructions to HHL page

### DIFF
--- a/notebooks/ch-applications/hhl_tutorial.ipynb
+++ b/notebooks/ch-applications/hhl_tutorial.ipynb
@@ -253,6 +253,12 @@
    "source": [
     "## A. Running HHL on a simulator: general method<a id='implementationsim'></a>\n",
     "\n",
+    "To run the code on this page, you'll need to install the [linear solvers package](https://github.com/anedumla/quantum_linear_solvers). you can do this through the command:\n",
+    "\n",
+    "```\n",
+    "pip install git+https://github.com/anedumla/quantum_linear_solvers\n",
+    "```\n",
+    "\n",
     "The interface for all algorithms to solve the linear system problem is `LinearSolver`. The problem to be solved is only specified when the `solve()` method is called:\n",
     "```python\n",
     "LinearSolver(...).solve(matrix, vector)\n",


### PR DESCRIPTION
## Changes

Adds instructions on installing the linear solvers package required for the HHL page, which isn't part of Qiskit, or available on `pip`.

See #1786 for more information.
