### PR TITLE
Handle display equations in blockquotes

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -262,8 +262,9 @@ def handle_markdown_cell(cell, resources, cell_number, is_problem_set=False):
                 markdown_lines.append("\n")
                 in_latex = True
             continue
-        if line.lstrip().startswith("$$"):
+        if line.lstrip(' >').startswith("$$"):
             indent, l = line.split("$$", 1)
+            indent = indent.replace('>', '')
             assert not indent or indent.isspace()
             markdown_lines.append(f"{indent}```latex\n")
             if l.rstrip(" .").endswith("$$"):
@@ -292,7 +293,7 @@ def handle_markdown_cell(cell, resources, cell_number, is_problem_set=False):
             continue
 
         if in_blockquote:
-            if not line.startswith(">"):
+            if not line.startswith(">") and not in_latex:
                 in_blockquote = False
                 markdown_lines.append("</blockquote>\n")
         if line.startswith(">"):


### PR DESCRIPTION
## Changes

Tweaks some converter logic to handle display equations inside blockquotes. This problem appears in the new basics page.

## Implementation details

Markdown blockquotes are indented with a chevron (`>`). Since the converter detects display equations as lines starting with `$$`, display equations inside blockquotes were not detected. The converter also ends a blockquote when lines are no longer indented with `>`.

This PR strips left chevrons in the same way as whitespace so display equations are detected, and will not close blockquotes until the display equation has ended.

## Screenshots

Before:

![Screenshot 2023-01-18 at 13 57 54](https://user-images.githubusercontent.com/36071638/213192231-6ca947f5-c0e4-46bc-a3ac-34790c84a2b3.png)

After:

![Screenshot 2023-01-18 at 13 58 22](https://user-images.githubusercontent.com/36071638/213192238-9a26d431-fd11-4c2f-8cd7-2bbb88998e3b.png)

The markdown:

```markdown

The *no-cloning theorem* shows it is impossible to create a perfect copy of an unknown quantum state.

> **Theorem (No-cloning theorem)**:
>
> Let $\mathsf{X}$ and $\mathsf{Y}$ be systems sharing the same classical state set $\Sigma$ having at least two elements. There does not exist a quantum state $\vert \phi\rangle$ of $\mathsf{Y}$ and a unitary operation $U$ on the pair $(\mathsf{X},\mathsf{Y})$ such that
>
> $$
    U \bigl( \vert \psi \rangle \otimes \vert\phi\rangle\bigr)
    = \vert \psi \rangle \otimes \vert\psi\rangle
    \tag{6}
  $$
>
> for every state $\vert \psi \rangle$ of $\mathsf{X}$.
 
```