### PR TITLE
Handle figures in markdown lists

### DIFF
--- a/converter/textbook-converter/textbook_converter/TextbookExporter.py
+++ b/converter/textbook-converter/textbook_converter/TextbookExporter.py
@@ -176,10 +176,11 @@ def handle_images(line, cell):
         figure: x-img(src="path/image")
 
     """
+    indent = line.split('!')[0]
     match = markdown_img_regex.search(line.lstrip())
     if match is not None:
         return f"""
-    figure: x-img(src="{get_attachment_data(match.group(1), cell)}")
+    {indent}figure: x-img(src="{get_attachment_data(match.group(1), cell)}")
         """
     else:
         return line


### PR DESCRIPTION
## Changes

Tweaks the converter to preserve image indentation so it's recognized as part of the list.


## Screenshots

Before:

<img width="712" alt="Screenshot 2023-01-19 at 12 06 31" src="https://user-images.githubusercontent.com/36071638/213438873-9f2bd211-9a69-44e6-8071-a0c0ae8ba1a2.png">

After:

<img width="712" alt="Screenshot 2023-01-19 at 11 52 18" src="https://user-images.githubusercontent.com/36071638/213435558-bf762b95-04fe-4fe3-900e-f05c204c7ec7.png">


Source markdown:

```markdown
1. The first operation is a Hadamard operation on $\mathsf{Y}$:

   ![First operation e-bit creator](images/quantum-circuits/ebit-circuit-first.png)

   When applying a gate to a single qubit like ...
```
