### PR TITLE
Fir apostrophe typo

### DIFF
--- a/notebooks/intro/atoms-of-computation.ipynb
+++ b/notebooks/intro/atoms-of-computation.ipynb
@@ -277,7 +277,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To do the simulation, we can use the simulators <code>.run()</code> method. This returns a \"job\", which contains information about the experiment, such as whether the experiment is running or completed, the backend it ran on, and (importantly for us), the results of the experiment.\n",
+    "To do the simulation, we can use the simulator’s <code>.run()</code> method. This returns a \"job\", which contains information about the experiment, such as whether the experiment is running or completed, the backend it ran on, and (importantly for us), the results of the experiment.\n",
     "\n",
     "To get the results from the job, we use the results method, and the most popular way to view the results is as a dictionary of \"counts\"."
    ]


### PR DESCRIPTION
## Changes

I believe there should be

>the simulato**r’s** `.run()` method

instead of

>the simulato**rs** `.run()` method

## Screenshot

![Untitled](https://user-images.githubusercontent.com/51094650/218341847-db74f65a-3750-43ba-a5ad-dcb7ee9bedd0.png)
