### PR TITLE
Update qiskit-terra req.

### DIFF
--- a/converter/textbook-converter/requirements-test.txt
+++ b/converter/textbook-converter/requirements-test.txt
@@ -3,12 +3,14 @@ cmake==3.24.1
 nbqa==1.3.1
 pylint==2.14.3
 scour==0.38.2
-qiskit==0.39.0
+qiskit-terra==0.23.2
+qiskit-aer==0.11.2
 qiskit-nature==0.4.1
 qiskit-machine-learning==0.4.0
 qiskit-finance==0.3.2
 qiskit-ibm-runtime==0.8.0
 scikit-learn==1.0.1
+tweedledum==1.1.1
 tensorflow==2.9.3
 matplotlib==3.5.2
 bokeh==3.0.2


### PR DESCRIPTION
## Changes

Updates `qiskit-terra` to `0.23.2` (required for #1959).

## Additional details

Unfortunately we can't use the `qiskit` meta package due to dependency conflicts with `qiskit-ibmq-provider` and the websockets package.
