### PR TITLE
Change register names

### DIFF
--- a/converter/textbook-converter/requirements-test.txt
+++ b/converter/textbook-converter/requirements-test.txt
@@ -3,7 +3,7 @@ cmake==3.24.1
 nbqa==1.3.1
 pylint==2.14.3
 scour==0.38.2
-qiskit-terra==0.23.2
+qiskit-terra==0.22
 qiskit-aer==0.11.2
 qiskit-nature==0.4.1
 qiskit-machine-learning==0.4.0

--- a/notebooks/basics/entanglement-in-action.ipynb
+++ b/notebooks/basics/entanglement-in-action.ipynb
@@ -1916,6 +1916,7 @@
     }
    ],
    "source": [
+    "# pylint: disable=unused-import\n",
     "import qiskit.tools.jupyter\n",
     "%qiskit_version_table"
    ]

--- a/notebooks/basics/entanglement-in-action.ipynb
+++ b/notebooks/basics/entanglement-in-action.ipynb
@@ -500,9 +500,9 @@
     "from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister\n",
     "\n",
     "# pylint: disable=invalid-name, not-context-manager\n",
-    "qubit = QuantumRegister(1, \"Q\")\n",
-    "ebit0 = QuantumRegister(1, \"A\")\n",
-    "ebit1 = QuantumRegister(1, \"B\")\n",
+    "qubit = QuantumRegister(1, \"qubit\")\n",
+    "ebit0 = QuantumRegister(1, \"qubit A\")\n",
+    "ebit1 = QuantumRegister(1, \"qubit B\")\n",
     "a = ClassicalRegister(1, \"a\")\n",
     "b = ClassicalRegister(1, \"b\")\n",
     "\n",
@@ -562,7 +562,7 @@
    "source": [
     "# Create a new circuit including the same bits and qubits used in the\n",
     "# teleportation protocol, along with a new \"auxiliary\" qubit R.\n",
-    "aux = QuantumRegister(1, \"R\")\n",
+    "aux = QuantumRegister(1, \"qubit R\")\n",
     "test = QuantumCircuit(aux, qubit, ebit0, ebit1, a, b)\n",
     "\n",
     "# Entangle Q with R\n",
@@ -580,7 +580,7 @@
     "# a new classical bit to the circuit to do this.\n",
     "test.cx(aux, ebit1)\n",
     "test.h(aux)\n",
-    "result = ClassicalRegister(1, \"Test result\")\n",
+    "result = ClassicalRegister(1, \"test result\")\n",
     "test.add_register(result)\n",
     "test.measure(aux, result)\n",
     "\n",
@@ -841,11 +841,11 @@
     "from qiskit import QuantumCircuit\n",
     "\n",
     "rbg = QuantumRegister(1, \"randomizer\")\n",
-    "ebit0 = QuantumRegister(1, \"A\")\n",
-    "ebit1 = QuantumRegister(1, \"B\")\n",
+    "ebit0 = QuantumRegister(1, \"qubit A\")\n",
+    "ebit1 = QuantumRegister(1, \"qubit B\")\n",
     "\n",
-    "Alice_a = ClassicalRegister(1, \"Alice a\")\n",
-    "Alice_b = ClassicalRegister(1, \"Alice b\")\n",
+    "Alice_a = ClassicalRegister(1, \"alice a\")\n",
+    "Alice_b = ClassicalRegister(1, \"alice b\")\n",
     "\n",
     "test = QuantumCircuit(rbg, ebit0, ebit1, Alice_b, Alice_a)\n",
     "\n",
@@ -874,8 +874,8 @@
     "test.h(ebit0)\n",
     "test.barrier()\n",
     "\n",
-    "Bob_a = ClassicalRegister(1, \"Bob a\")\n",
-    "Bob_b = ClassicalRegister(1, \"Bob b\")\n",
+    "Bob_a = ClassicalRegister(1, \"bob a\")\n",
+    "Bob_b = ClassicalRegister(1, \"bob b\")\n",
     "test.add_register(Bob_b)\n",
     "test.add_register(Bob_a)\n",
     "test.measure(ebit1, Bob_a)\n",
@@ -1894,6 +1894,30 @@
    "metadata": {},
    "source": [
     "Although there's randomness involved, the statistics are very unlikely to deviate too much after 1,000 runs. The quantum strategy wins about 85% of the time while a classical strategy can't win more than about 75% of the time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "8a54d786",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<h3>Version Information</h3><table><tr><th>Qiskit Software</th><th>Version</th></tr><tr><td><code>qiskit-terra</code></td><td>0.22.0</td></tr><tr><td><code>qiskit-aer</code></td><td>0.11.2</td></tr><tr><td><code>qiskit-ibmq-provider</code></td><td>0.20.0</td></tr><tr><td><code>qiskit</code></td><td>0.6.1</td></tr><tr><td><code>qiskit-nature</code></td><td>0.4.1</td></tr><tr><td><code>qiskit-finance</code></td><td>0.3.2</td></tr><tr><td><code>qiskit-optimization</code></td><td>0.5.0</td></tr><tr><td><code>qiskit-machine-learning</code></td><td>0.4.0</td></tr><tr><th>System information</th></tr><tr><td>Python version</td><td>3.8.16</td></tr><tr><td>Python compiler</td><td>Clang 14.0.0 (clang-1400.0.29.202)</td></tr><tr><td>Python build</td><td>default, Dec  7 2022 01:36:11</td></tr><tr><td>OS</td><td>Darwin</td></tr><tr><td>CPUs</td><td>8</td></tr><tr><td>Memory (Gb)</td><td>32.0</td></tr><tr><td colspan='2'>Thu Mar 02 18:31:43 2023 GMT</td></tr></table>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import qiskit.tools.jupyter\n",
+    "%qiskit_version_table"
    ]
   }
  ],


### PR DESCRIPTION
## Changes

- Changes the register names so they're valid with `qiskit-terra==0.22`
- Added the version table at the bottom

## Context

The original plan had been to upgrade the Terra version before this was released, but we've hit some dependency problems. This PR should be reverted once these are resolved.
