### PR TITLE
Update qiskit and qiskit_ibm_runtime

### DIFF
--- a/converter/textbook-converter/requirements-test.txt
+++ b/converter/textbook-converter/requirements-test.txt
@@ -3,14 +3,13 @@ cmake==3.24.1
 nbqa==1.3.1
 pylint==2.14.3
 scour==0.38.2
-qiskit-terra==0.23.2
-qiskit-aer==0.11.2
+qiskit==0.41.1
+tweedledum==1.1.1
 qiskit-nature==0.4.1
 qiskit-machine-learning==0.4.0
 qiskit-finance==0.3.2
-qiskit-ibm-runtime==0.8.0
+qiskit-ibm-runtime==0.9.1
 scikit-learn==1.0.1
-tweedledum==1.1.1
 tensorflow==2.9.3
 matplotlib==3.5.2
 bokeh==3.0.2


### PR DESCRIPTION
## Changes

As of yesterday, the latest `qiskit_ibm_runtime` no longer has a dependency conflict with `qiskit==0.41.1`, so we can upgrade both. This removes the need for #1969.

Also see https://github.com/Qiskit/platypus-binder/pull/33

`nb_autorun` output:
<img width="613" alt="Screenshot 2023-03-03 at 14 02 22" src="https://user-images.githubusercontent.com/36071638/222745099-a554f3b5-619d-42fe-9f35-d7af1d82f0ca.png">

