### PR TITLE
update latex expression

### DIFF
--- a/notebooks/ch-algorithms/quantum-walk-search-algorithm.ipynb
+++ b/notebooks/ch-algorithms/quantum-walk-search-algorithm.ipynb
@@ -104,7 +104,7 @@
     "    \\ket{\\psi_j} := \\sum_{k=1}^N \\sqrt{P_{kj}} \\ket{j,k}, \\; j=1,...,N\n",
     "\\end{equation}\n",
     "\n",
-    "and the projection onto ${\\ket{\\psi_j}}:j=1,...,N$\n",
+    "and the projection onto $\\ket{\\psi_j}:j=1,...,N$\n",
     "\n",
     "\\begin{equation}\n",
     "    \\Pi := \\sum_{j=1}^N \\ket{\\psi_j} \\bra{\\psi_j}\n",


### PR DESCRIPTION
## Changes

this pr updates latex expression which was causing rendering issues

Fixes #1915 

## Implementation details

removes `{}` around an expression which was throwing the error

`Expression parsing error at character 0 of "\ket{\psi_j"`

## How to read this PR

- review changes to latex expression
- check page & expression in preview link

## Screenshots

**BEFORE**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/223643685-4d96e960-7531-46bf-8501-eb0f38fbf076.png">

**AFTER**

<img width="800" alt="image" src="https://user-images.githubusercontent.com/13156555/223643938-f2ce969d-4e6d-4ace-ac6c-90fcd77a360e.png">

