### PR TITLE
Adds missing pages to Mega Menu and fixes Coin sidebar

### DIFF
--- a/frontend/vue/components/constants/megaMenuLinks.ts
+++ b/frontend/vue/components/constants/megaMenuLinks.ts
@@ -392,6 +392,27 @@ const GAMES_AND_DEMOS: MegaDropdownMenuGroup = {
       segment: {
         cta: 'widgets-demonstration', location: sectionGamesAndDemos
       }
+    },
+    {
+      label: 'Quantum Coin Game',
+      url: `${pathGamesAndDemos}/coin-game`,
+      segment: {
+        cta: 'coin-game', location: sectionGamesAndDemos
+      }
+    },
+    {
+      label: 'First Quantum Game',
+      url: `${pathGamesAndDemos}/first-quantum-game`,
+      segment: {
+        cta: 'first-quantum-game', location: sectionGamesAndDemos
+      }
+    },
+    {
+      label: 'Variational Quantum Regression',
+      url: `${pathGamesAndDemos}/variational-quantum-regression`,
+      segment: {
+        cta: 'variational-quantum-regression', location: sectionGamesAndDemos
+      }
     }
   ]
 }
@@ -623,6 +644,20 @@ const QUANTUM_ALGORITHMS_FOR_APPS : MegaDropdownMenuGroup = {
       url: `${pathApps}/flexible-representation-of-quantum-images-frqi`,
       segment: {
         cta: 'flexible-representation-of-quantum-images-frqi', location: sectionApps
+      }
+    },
+    {
+      label: 'Quantum Edge Detection',
+      url: `${pathApps}/quantum-edge-detection`,
+      segment: {
+        cta: 'quantum-edge-detection', location: sectionApps
+      }
+    },
+    {
+      label: 'Travelling Salesman Problem',
+      url: `${pathApps}/tsp`,
+      segment: {
+        cta: 'tsp', location: sectionApps
       }
     }
   ]

--- a/notebooks/ch-applications/image-processing-frqi-neqr.ipynb
+++ b/notebooks/ch-applications/image-processing-frqi-neqr.ipynb
@@ -8,7 +8,7 @@
     ]
    },
    "source": [
-    "# Flexible Representation of Quantum Images (FRQI)"
+    "# Flexible Representation of Quantum Images (FRQI) and Novel Enhanced Quantum Representation (NEQR)"
    ]
   },
   {

--- a/notebooks/ch-demos/coin-game.ipynb
+++ b/notebooks/ch-demos/coin-game.ipynb
@@ -272,7 +272,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### **Optimal Strategy** <a id=\"optimal\"></a>"
+    "### Optimal Strategy <a id=\"optimal\"></a>"
    ]
   },
   {
@@ -341,7 +341,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### **Lets play this version using Qiskit** <a id=\"quantum_play\"></a>"
+    "### Lets play this version using Qiskit <a id=\"quantum_play\"></a>"
    ]
   },
   {


### PR DESCRIPTION
Adds 5 pages that were missing from the mega menu to it, changes the header of the FQRI page to better summarize the contents of the page, and fixes the sidebar of the Quantum Coin Game page to not have extra asterisks in it.

Fixes #2002, Fixes #2003 , Fixes #2004 