### PR TITLE
Fix typo in Multiple Systems page

### DIFF
--- a/notebooks/basics/multiple-systems.ipynb
+++ b/notebooks/basics/multiple-systems.ipynb
@@ -1789,7 +1789,7 @@
     "\n",
     "For other measurement outcomes the state can be determined in a similar way.\n",
     "\n",
-    "Now, it must be understood that the tensor product is not commutative: if $\\vert \\phi\\rangle$ and $\\vert \\pi \\rangle$ are vectors, then, in general, $\\vert \\phi\\rangle\\otimes\\vert \\pi \\rangle$ is different from $\\vert \\phi\\rangle\\otimes\\vert \\pi \\rangle$, and likewise for tensor products of three or more vectors.\n",
+    "Now, it must be understood that the tensor product is not commutative: if $\\vert \\phi\\rangle$ and $\\vert \\pi \\rangle$ are vectors, then, in general, $\\vert \\phi\\rangle\\otimes\\vert \\pi \\rangle$ is different from $\\vert \\pi\\rangle\\otimes\\vert \\phi \\rangle$, and likewise for tensor products of three or more vectors.\n",
     "For instance, \n",
     "$\\vert\\heartsuit\\rangle \\vert\\clubsuit\\rangle \\vert\\diamondsuit\\rangle \\vert\\spadesuit\\rangle \\vert\\spadesuit\\rangle$\n",
     "is a different vector than \n",


### PR DESCRIPTION
Fixes #2017

A quick change to correct a typo in the explanation of tensor products.