### PR TITLE
remove beta

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ contributors and maintainers of this site and so, thank you!
 
 ## Start contributing
 
-This repository is for developing and maintaining the Qiskit Textbook (beta) platform.
+This repository is for developing and maintaining the Qiskit Textbook platform.
 If you want to contribute to Qiskit, the open-source Python library, you should go
 visit the [Qiskit repository](https://github.com/Qiskit/qiskit) instead.
 Or if you want to contribute to the [qiskit.org website](https://qiskit.org), you should go

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # platypus
-This repository is home of the new [Qiskit Textbook (beta)](https://qiskit.org/learn/).
+This repository is home of the new [Qiskit Textbook](https://qiskit.org/learn/).
 
 The previous version of the Qiskit Textbook textbook can be found [here](https://github.com/qiskit-community/qiskit-textbook).
 

--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -73,7 +73,7 @@ Please refer to the [Release Guide](https://github.com/Qiskit/platypus/blob/main
 
 ## When you find an issue in the textbook
 
-During the process of translating Qiskit Textbook (beta), you may identify bug or errors regarding the original textbook content. Please feel free to suggest corrections by opening an [issue](https://github.com/Qiskit/platypus/issues/new/choose).
+During the process of translating Qiskit Textbook, you may identify bug or errors regarding the original textbook content. Please feel free to suggest corrections by opening an [issue](https://github.com/Qiskit/platypus/issues/new/choose).
 
 ## Project Leads
 

--- a/docs/deployments.md
+++ b/docs/deployments.md
@@ -1,10 +1,10 @@
-# Deploying Textbook Beta
+# Deploying Textbook
 
 Core contributors from qiskit.org, along with other core developers, are responsible for the codebases's health. Here you will find the specifics our continuous integration process.
 
 ### Deployment
 
-The Textbook beta application uses [GitHub Actions](https://docs.github.com/en/actions) to automate releases. This enables us to establish a Workflow and specify various steps that we need to include in our build process.
+The Textbook application uses [GitHub Actions](https://docs.github.com/en/actions) to automate releases. This enables us to establish a Workflow and specify various steps that we need to include in our build process.
 
 In the current configuration, the `Build and Release` Workflow is initiated by the following events:
 
@@ -22,7 +22,7 @@ This `Build and Release` process includes the following steps:
 - generates the build
 - deploys to AppEngine
 
-Details for the `Deploy to AppEngine` step can be found by visiting the GitHub Action page [here](https://github.com/google-github-actions/deploy-appengine). (This AppEngine instance belongs to Mathigon). Additionally, `secrets` used for deploying are maintained through a joint effort between the Qiskit Textbook Beta and Mathigon.
+Details for the `Deploy to AppEngine` step can be found by visiting the GitHub Action page [here](https://github.com/google-github-actions/deploy-appengine). (This AppEngine instance belongs to Mathigon). Additionally, `secrets` used for deploying are maintained through a joint effort between the Qiskit Textbook and Mathigon.
 
 
 ### Live branch previews

--- a/server/templates/textbook.pug
+++ b/server/templates/textbook.pug
@@ -18,7 +18,7 @@ html(lang=course.locale dir=dir)
         include sidebar
 
         article.c-textbook__page(data-test="textbook-page" tabindex="0")
-          include banner
+          // include banner
           .reveal-banner
             | #{__('Reading time')}: ~#{section.duration} min
             // keep this for mathigon stuff

--- a/server/templates/textbook.pug
+++ b/server/templates/textbook.pug
@@ -18,7 +18,7 @@ html(lang=course.locale dir=dir)
         include sidebar
 
         article.c-textbook__page(data-test="textbook-page" tabindex="0")
-          // include banner
+          include banner
           .reveal-banner
             | #{__('Reading time')}: ~#{section.duration} min
             // keep this for mathigon stuff


### PR DESCRIPTION
this PR is part of a bigger set of changes required as the Textbook gets re-organized/versioned: https://github.com/Qiskit/platypus/issues/2046

## Changes

this PR removes references to `beta` <!-- and remove the banner to old textbook -->

## Implementation details

- remove `beta` word from title/name in various docs

## How to read this PR

- review changes in updated file

<!--
## Screenshots

**before**

![image](https://user-images.githubusercontent.com/13156555/229882103-cfcf18af-08aa-49e3-9240-7b22002ba22c.png)

**after**

![image](https://user-images.githubusercontent.com/13156555/229882299-ca50e8d2-aac9-4c5e-8471-d2e059507c86.png)
-->

