### PR TITLE
Skip running problem-sets notebooks in CI

### DIFF
--- a/scripts/content_checks/nb_autorun.py
+++ b/scripts/content_checks/nb_autorun.py
@@ -154,6 +154,10 @@ if __name__ == '__main__':
     # Start executing notebooks
     print('\n\033[?25l', end="")  # hide cursor
     for path in filepaths:
+        if 'problem-sets' in path.parts:
+            # Don't want to run these notebooks
+            print(f'- Skipping {path}')
+            continue
         log['total_files'] += 1
         print('-', timestr(), path, end=' ', flush=True)
 


### PR DESCRIPTION
These notebooks are intentionally incomplete and it's expected that they don't
run top-to-bottom without errors.
