### PR TITLE
Fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,14 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Clone Qiskit/textbook repo
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${{ secrets.TEXTBOOK_REPO_CLONE_KEY }}"
-          git config --global url."git@github.com:".insteadOf "https://github.com"
-          git submodule update --init --recursive
-          git config --global url."git@github.com:".insteadOf "https://github.com"
-
       - uses: actions/setup-node@v3
         with:
           node-version: "16"


### PR DESCRIPTION
## Changes

Skip the Qiskit/textbook cloning process as we now just copy the released folder over to the repo and commit it. This script was overlooked in #2042.
