### PR TITLE
Skip cloning Qiskit/textbook in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,14 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Clone Qiskit/textbook repo
-        run: |
-          eval `ssh-agent -s`
-          ssh-add - <<< "${{ secrets.TEXTBOOK_REPO_CLONE_KEY }}"
-          git config --global url."git@github.com:".insteadOf "https://github.com"
-          git submodule update --init --recursive
-          git config --global --remove-section url."git@github.com:"
-
       - uses: actions/setup-node@v3
         with:
           node-version: "16"


### PR DESCRIPTION
## Changes

This step was added back when we were using Git submodules, which we don't any more.
