### PR TITLE
copy course data before editing

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -220,7 +220,10 @@ const start = () => {
       // displays content from /course/v1_introduction/why-quantum-computing
       // :version - refers to the textbook version
       req.params.course = `${req.params.version}_${req.params.course}`
-      const courseData = await getCourseData(req)
+      const cachedCourseData = await getCourseData(req)
+
+      // make a copy of course data before editing
+      const courseData = JSON.parse(JSON.stringify(cachedCourseData))
 
       courseData?.course.sections.forEach((section: any) => {
         // change to form /v1/course/introduction/...


### PR DESCRIPTION
this PR addresses an issue where section URL of versioned content continues to get the version appended

<details>
    <summary>section link url</summary>
    <img src="https://user-images.githubusercontent.com/13156555/234073188-2215c977-0d22-4b4f-a475-50697c2f676d.png" />
</details>


## Changes

copy course data before editing it

## Implementation details

-  a copy of the (cached) course data is made
- edits can be made to copy

## How to read this PR

- review changed file


