### PR TITLE
Redirect images used in the QPE tutorial notebook

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -4,6 +4,12 @@ runtime: nodejs
 env: flex
 
 handlers:
+  # Images used in the QPE tutorial notebook in Challenges portal for QAL
+  - url: /content/ch-algorithms/images/(.*\.(gif|png|jpg|svg))$
+    static_files: content/v2/ch-algorithms/images/\1
+    upload: content/v2/ch-algorithms/images/.*\.(gif|png|jpg|svg)$
+    redirect_http_response_code: 301
+
   - url: /.*
     script: app.js
     secure: always


### PR DESCRIPTION
## Changes

Redirect images used in the QPE tutorial notebook

Reference:
- https://cloud.google.com/appengine/docs/standard/reference/app-yaml?tab=node.js#handlers_element