### PR TITLE
copy version assets

### DIFF
--- a/converter/common.ts
+++ b/converter/common.ts
@@ -3,6 +3,9 @@ import * as path from 'path'
 import * as fs from 'fs-extra'
 import { load as loadYAML } from 'js-yaml'
 
+// NOTE: if changing this also update the same variable in 'server/utilities.ts'
+const LATEST_TEXTBOOK_VERSION = 'v2'
+
 const CWD = process.cwd()
 
 // Get the languages to translate from the mathigon config file or throw an error
@@ -23,5 +26,6 @@ const workingTranslationsPath = path.join(CWD, 'working', 'translations')
 export {
   translationsLanguages,
   workingContentPath,
-  workingTranslationsPath
+  workingTranslationsPath,
+  LATEST_TEXTBOOK_VERSION
 }

--- a/converter/converter.ts
+++ b/converter/converter.ts
@@ -6,7 +6,8 @@ import * as fs from 'fs-extra'
 import {
   translationsLanguages,
   workingContentPath,
-  workingTranslationsPath
+  workingTranslationsPath,
+  LATEST_TEXTBOOK_VERSION
 } from './common'
 
 const CWD = process.cwd()
@@ -92,9 +93,15 @@ const prepare = function (language: string) {
   copyNotebookAssets(notebooks, working, (src: string, dest: string) => {
     return path.dirname(src).split(path.sep).indexOf(nbImagesDirName) > -1
   })
+  copyNotebookAssets(`${notebooks}${path.sep}${LATEST_TEXTBOOK_VERSION}`, working, (src: string, dest: string) => {
+    return path.dirname(src).split(path.sep).indexOf(nbImagesDirName) > -1
+  })
 
   // copy over notebook `resources/`
   copyNotebookAssets(notebooks, working, (src: string, dest: string) => {
+    return path.dirname(src).split(path.sep).indexOf(nbResourcesDirName) > -1
+  })
+  copyNotebookAssets(`${notebooks}${path.sep}${LATEST_TEXTBOOK_VERSION}`, working, (src: string, dest: string) => {
     return path.dirname(src).split(path.sep).indexOf(nbResourcesDirName) > -1
   })
 }

--- a/converter/textbook-converter/requirements.txt
+++ b/converter/textbook-converter/requirements.txt
@@ -1,3 +1,4 @@
+Cython<3.0
 ipython>=6
 nbformat>=4
 nbconvert>=5

--- a/converter/textbook-converter/requirements.txt
+++ b/converter/textbook-converter/requirements.txt
@@ -1,6 +1,5 @@
-Cython<3.0
 ipython>=6
 nbformat>=4
 nbconvert>=5
 requests
-pyyaml
+pyyaml==5.3.1

--- a/server/utilities.ts
+++ b/server/utilities.ts
@@ -25,6 +25,7 @@ import { IS_PRODUCTION } from './configuration'
 
 const TEXTBOOK_HOME = 'https://qiskit.org/learn'
 
+// NOTE: if changing this also update the same variable in 'converter/common.ts'
 const LATEST_TEXTBOOK_VERSION = 'v2'
 
 const DEFAULT_SHARED_FOLDER = path.join(CONTENT_DIR, 'shared')


### PR DESCRIPTION
## Changes

copy assets from latest version into `working/`

related https://github.com/Qiskit/platypus/pull/2159


## Implementation details

assets (i.e., images, etc.) that are in the latest version (e.g., `v2`) are copied into `working/`

## How to read this PR

review changes to `converter.ts`


