### PR TITLE
chore: upgrade to latest qiskit/web-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@mathigon/euclid": "^1.1.11",
         "@mathigon/studio": "0.1.18",
         "@qiskit-community/qiskit-vue": "^3.4.0",
-        "@qiskit/web-components": "^0.10.3",
+        "@qiskit/web-components": "^0.15.3",
         "@webcomponents/webcomponentsjs": "^2.6.0",
         "carbon-components": "~10.58.3",
         "carbon-web-components": "^1.21.0",
@@ -430,9 +430,9 @@
       "integrity": "sha512-YXed2JUSCGddp3UnY5OffR3W8Pl+dy9a+vfUtYhSLH9TbIEBR6EvYIfvruFMhA8JIVMCUClUqgyMQXM5oMFQ0g=="
     },
     "node_modules/@carbon/icons": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.5.0.tgz",
-      "integrity": "sha512-2k6TGPsqxQunVsWK6b/zWUQ2tjVFBBxCWRI2shJcgu016XsslMWs+zAa0ASZ7MYxOrhgisDmGvXQDVRU7MF68A=="
+      "version": "11.26.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.26.0.tgz",
+      "integrity": "sha512-YRYSnbZ3yBkH7i/Ne7VOwaf8ytL+bLed5ZWyjsdpagJyvG3g1CXQRvEub2vvXGis089s1z42rgU4pgLoyKjwVw=="
     },
     "node_modules/@carbon/icons-vue": {
       "version": "10.48.0",
@@ -576,6 +576,41 @@
         "@vue/compiler-sfc": "2.7.14",
         "csstype": "^3.1.0"
       }
+    },
+    "node_modules/@carbon/web-components": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-1.31.0.tgz",
+      "integrity": "sha512-VW+B24snyYnt7PSwpT3qhmtKcQW1+KlzfED3jN9ubuOYmUzbOsTqzMFay0zKB7e0Ublrlv+utkgvN6EUxd4CUg==",
+      "dependencies": {
+        "@babel/runtime": "^7.16.3",
+        "carbon-components": "10.58.3",
+        "flatpickr": "4.6.13",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/@carbon/web-components/node_modules/carbon-components": {
+      "version": "10.58.3",
+      "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.58.3.tgz",
+      "integrity": "sha512-RjTnrWCGStsIZ7nErw97AZI9sQWxQ8oIgo3QMdV0FWFcpTOECA4I9Dy4WPpRRdSMBcQpLetTxqjDGourM4u8Tw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@carbon/telemetry": "0.1.0",
+        "flatpickr": "4.6.1",
+        "lodash.debounce": "^4.0.8",
+        "warning": "^3.0.0"
+      }
+    },
+    "node_modules/@carbon/web-components/node_modules/carbon-components/node_modules/flatpickr": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.1.tgz",
+      "integrity": "sha512-3ULSxbXmcMIRzer/2jLNweoqHpwDvsjEawO2FUd9UFR8uPwLM+LruZcPDpuZStcEgbQKhuFOfXo4nYdGladSNw=="
+    },
+    "node_modules/@carbon/web-components/node_modules/flatpickr": {
+      "version": "4.6.13",
+      "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+      "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
     },
     "node_modules/@ckeditor/ckeditor5-adapter-ckfinder": {
       "version": "34.2.0",
@@ -2251,10 +2286,18 @@
         "@lezer/lr": "^1.0.0"
       }
     },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
     "node_modules/@lit/reactive-element": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.1.tgz",
-      "integrity": "sha512-qDv4851VFSaBWzpS02cXHclo40jsbAjRXnebNXpm0uVg32kCneZPo9RYVQtrTNICtZ+1wAYHu1ZtxWSWMbKrBw=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "node_modules/@lumino/algorithm": {
       "version": "1.9.2",
@@ -2846,58 +2889,59 @@
       }
     },
     "node_modules/@qiskit/web-components": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.10.3.tgz",
-      "integrity": "sha512-Y7dVqBipkwElkSK0AjplAZ4sCeL1jTSieG9GXpK5EOYGg6l9O6eAAGP1wixGwiILUjXQVBhMgrtd+BBIoqNOrw==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.15.3.tgz",
+      "integrity": "sha512-FrILLujBDEefCbx6+mfbs2NB6yS5w5dcjBj9PW3fkSGcCV5bhlhWr6tm4Ee5c0BBfJLbOKf7W+Spr8Myo3lGMQ==",
       "dependencies": {
         "@carbon/colors": "^10.37.1",
         "@carbon/icon-helpers": "^10.30.0",
         "@carbon/icons": "^11.3.0",
         "@carbon/layout": "^10.37.1",
-        "@carbon/type": "^10.45.0",
-        "carbon-web-components": "^1.21.0",
-        "lit": "^2.4.1",
+        "@carbon/type": "^10.45.1",
+        "@carbon/web-components": "^1.25.0",
+        "lit": "^2.6.1",
         "lit-element": "^3.2.2",
-        "lit-html": "^2.4.0",
-        "tslib": "^2.4.1"
+        "lit-html": "^2.6.1",
+        "tslib": "^2.5.0"
       }
     },
     "node_modules/@qiskit/web-components/node_modules/@carbon/grid": {
-      "version": "10.43.1",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-10.43.1.tgz",
-      "integrity": "sha512-gBfAEIfso5GjYPB1+BHjpNIfzDzBHb8xz9GRBhdrTlDVw9RJ4KH4MfYDeObiFQ/I7/6YCOE+LjjLv/BTm9iWBQ==",
+      "version": "10.43.2",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-10.43.2.tgz",
+      "integrity": "sha512-chhjz7cNl7TdKJ1MVhpXlNwtuKmdgWYygQFLShv1FnY9atMYv42hguGG289TZgPOuMpgYLyA9VOCS4IDVjC/1A==",
       "dependencies": {
         "@carbon/import-once": "^10.7.0",
-        "@carbon/layout": "^10.37.1"
+        "@carbon/layout": "^10.37.2"
       }
     },
     "node_modules/@qiskit/web-components/node_modules/@carbon/layout": {
-      "version": "10.37.1",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-10.37.1.tgz",
-      "integrity": "sha512-iX8rWc2CkFB7W7wi5NLa3pVRVb/jRI2KrVDna3FO3X3DgNz3zoRCgN+r2c+8FEhpJWeUwds5aDzTWUuTtlOT3w=="
+      "version": "10.37.2",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-10.37.2.tgz",
+      "integrity": "sha512-PRw9yxbMWy2ovAkIkIDxSkVVR7lYfXUBIRO8lD/nw+X+jLDh+cIIIsB5YHA5VpOYCx9iQr2g9dRmoNgCmOVkrg=="
     },
     "node_modules/@qiskit/web-components/node_modules/@carbon/type": {
-      "version": "10.45.1",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.45.1.tgz",
-      "integrity": "sha512-c7+5xDu6VXrseC578ED/qiZkoxCPZCRrgXE/ruFFQSsW2URLUGV6naxIbNewUnJ/pyIliGBCUKzQP8FDvGSvWA==",
+      "version": "10.45.3",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.45.3.tgz",
+      "integrity": "sha512-o/1vy59+IMjNCSyfS58Z5zQT10IuSt9SP/r631UbPLuVgotWWjACe57M5gxyCJHv2ZTIoTkP6dWFoomVSOPDjg==",
       "dependencies": {
-        "@carbon/grid": "^10.43.0",
+        "@carbon/grid": "^10.43.2",
         "@carbon/import-once": "^10.7.0"
       }
     },
     "node_modules/@qiskit/web-components/node_modules/lit-element": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/@qiskit/web-components/node_modules/lit-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
-      "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -3451,9 +3495,9 @@
       "dev": true
     },
     "node_modules/@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "node_modules/@types/uglify-js": {
       "version": "3.13.3",
@@ -15418,13 +15462,13 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.4.1.tgz",
-      "integrity": "sha512-qohSgLiyN1cFnJG26dIiY03S4F49857A0AHQfnS0zYtnUVnD2MFvx+UT52rtXsIuNFQrnUupX+zyGSATlk1f/A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "dependencies": {
-        "@lit/reactive-element": "^1.4.0",
-        "lit-element": "^3.2.0",
-        "lit-html": "^2.4.0"
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-element": {
@@ -15441,18 +15485,19 @@
       "integrity": "sha512-B9btcSgPYb1q4oSOb/PrOT6Z/H+r6xuNzfH4lFli/AWhYwdtrgQkQWBbIc6mdnf6E2IL3gDXdkkqNktpU0OZQA=="
     },
     "node_modules/lit/node_modules/lit-element": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
         "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.2.0"
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit/node_modules/lit-html": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
-      "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -25076,9 +25121,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tslint": {
       "version": "5.20.1",
@@ -28422,9 +28467,9 @@
       "integrity": "sha512-YXed2JUSCGddp3UnY5OffR3W8Pl+dy9a+vfUtYhSLH9TbIEBR6EvYIfvruFMhA8JIVMCUClUqgyMQXM5oMFQ0g=="
     },
     "@carbon/icons": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.5.0.tgz",
-      "integrity": "sha512-2k6TGPsqxQunVsWK6b/zWUQ2tjVFBBxCWRI2shJcgu016XsslMWs+zAa0ASZ7MYxOrhgisDmGvXQDVRU7MF68A=="
+      "version": "11.26.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icons/-/icons-11.26.0.tgz",
+      "integrity": "sha512-YRYSnbZ3yBkH7i/Ne7VOwaf8ytL+bLed5ZWyjsdpagJyvG3g1CXQRvEub2vvXGis089s1z42rgU4pgLoyKjwVw=="
     },
     "@carbon/icons-vue": {
       "version": "10.48.0",
@@ -28543,6 +28588,44 @@
             "@vue/compiler-sfc": "2.7.14",
             "csstype": "^3.1.0"
           }
+        }
+      }
+    },
+    "@carbon/web-components": {
+      "version": "1.31.0",
+      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-1.31.0.tgz",
+      "integrity": "sha512-VW+B24snyYnt7PSwpT3qhmtKcQW1+KlzfED3jN9ubuOYmUzbOsTqzMFay0zKB7e0Ublrlv+utkgvN6EUxd4CUg==",
+      "requires": {
+        "@babel/runtime": "^7.16.3",
+        "carbon-components": "10.58.3",
+        "flatpickr": "4.6.13",
+        "lit-element": "^2.5.1",
+        "lit-html": "^1.4.1",
+        "lodash-es": "^4.17.21"
+      },
+      "dependencies": {
+        "carbon-components": {
+          "version": "10.58.3",
+          "resolved": "https://registry.npmjs.org/carbon-components/-/carbon-components-10.58.3.tgz",
+          "integrity": "sha512-RjTnrWCGStsIZ7nErw97AZI9sQWxQ8oIgo3QMdV0FWFcpTOECA4I9Dy4WPpRRdSMBcQpLetTxqjDGourM4u8Tw==",
+          "requires": {
+            "@carbon/telemetry": "0.1.0",
+            "flatpickr": "4.6.1",
+            "lodash.debounce": "^4.0.8",
+            "warning": "^3.0.0"
+          },
+          "dependencies": {
+            "flatpickr": {
+              "version": "4.6.1",
+              "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.1.tgz",
+              "integrity": "sha512-3ULSxbXmcMIRzer/2jLNweoqHpwDvsjEawO2FUd9UFR8uPwLM+LruZcPDpuZStcEgbQKhuFOfXo4nYdGladSNw=="
+            }
+          }
+        },
+        "flatpickr": {
+          "version": "4.6.13",
+          "resolved": "https://registry.npmjs.org/flatpickr/-/flatpickr-4.6.13.tgz",
+          "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
         }
       }
     },
@@ -29990,10 +30073,18 @@
         "@lezer/lr": "^1.0.0"
       }
     },
+    "@lit-labs/ssr-dom-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.1.tgz",
+      "integrity": "sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ=="
+    },
     "@lit/reactive-element": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.4.1.tgz",
-      "integrity": "sha512-qDv4851VFSaBWzpS02cXHclo40jsbAjRXnebNXpm0uVg32kCneZPo9RYVQtrTNICtZ+1wAYHu1ZtxWSWMbKrBw=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
+      "requires": {
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
+      }
     },
     "@lumino/algorithm": {
       "version": "1.9.2",
@@ -30491,58 +30582,59 @@
       }
     },
     "@qiskit/web-components": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.10.3.tgz",
-      "integrity": "sha512-Y7dVqBipkwElkSK0AjplAZ4sCeL1jTSieG9GXpK5EOYGg6l9O6eAAGP1wixGwiILUjXQVBhMgrtd+BBIoqNOrw==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@qiskit/web-components/-/web-components-0.15.3.tgz",
+      "integrity": "sha512-FrILLujBDEefCbx6+mfbs2NB6yS5w5dcjBj9PW3fkSGcCV5bhlhWr6tm4Ee5c0BBfJLbOKf7W+Spr8Myo3lGMQ==",
       "requires": {
         "@carbon/colors": "^10.37.1",
         "@carbon/icon-helpers": "^10.30.0",
         "@carbon/icons": "^11.3.0",
         "@carbon/layout": "^10.37.1",
-        "@carbon/type": "^10.45.0",
-        "carbon-web-components": "^1.21.0",
-        "lit": "^2.4.1",
+        "@carbon/type": "^10.45.1",
+        "@carbon/web-components": "^1.25.0",
+        "lit": "^2.6.1",
         "lit-element": "^3.2.2",
-        "lit-html": "^2.4.0",
-        "tslib": "^2.4.1"
+        "lit-html": "^2.6.1",
+        "tslib": "^2.5.0"
       },
       "dependencies": {
         "@carbon/grid": {
-          "version": "10.43.1",
-          "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-10.43.1.tgz",
-          "integrity": "sha512-gBfAEIfso5GjYPB1+BHjpNIfzDzBHb8xz9GRBhdrTlDVw9RJ4KH4MfYDeObiFQ/I7/6YCOE+LjjLv/BTm9iWBQ==",
+          "version": "10.43.2",
+          "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-10.43.2.tgz",
+          "integrity": "sha512-chhjz7cNl7TdKJ1MVhpXlNwtuKmdgWYygQFLShv1FnY9atMYv42hguGG289TZgPOuMpgYLyA9VOCS4IDVjC/1A==",
           "requires": {
             "@carbon/import-once": "^10.7.0",
-            "@carbon/layout": "^10.37.1"
+            "@carbon/layout": "^10.37.2"
           }
         },
         "@carbon/layout": {
-          "version": "10.37.1",
-          "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-10.37.1.tgz",
-          "integrity": "sha512-iX8rWc2CkFB7W7wi5NLa3pVRVb/jRI2KrVDna3FO3X3DgNz3zoRCgN+r2c+8FEhpJWeUwds5aDzTWUuTtlOT3w=="
+          "version": "10.37.2",
+          "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-10.37.2.tgz",
+          "integrity": "sha512-PRw9yxbMWy2ovAkIkIDxSkVVR7lYfXUBIRO8lD/nw+X+jLDh+cIIIsB5YHA5VpOYCx9iQr2g9dRmoNgCmOVkrg=="
         },
         "@carbon/type": {
-          "version": "10.45.1",
-          "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.45.1.tgz",
-          "integrity": "sha512-c7+5xDu6VXrseC578ED/qiZkoxCPZCRrgXE/ruFFQSsW2URLUGV6naxIbNewUnJ/pyIliGBCUKzQP8FDvGSvWA==",
+          "version": "10.45.3",
+          "resolved": "https://registry.npmjs.org/@carbon/type/-/type-10.45.3.tgz",
+          "integrity": "sha512-o/1vy59+IMjNCSyfS58Z5zQT10IuSt9SP/r631UbPLuVgotWWjACe57M5gxyCJHv2ZTIoTkP6dWFoomVSOPDjg==",
           "requires": {
-            "@carbon/grid": "^10.43.0",
+            "@carbon/grid": "^10.43.2",
             "@carbon/import-once": "^10.7.0"
           }
         },
         "lit-element": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-          "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+          "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
           "requires": {
+            "@lit-labs/ssr-dom-shim": "^1.1.0",
             "@lit/reactive-element": "^1.3.0",
-            "lit-html": "^2.2.0"
+            "lit-html": "^2.8.0"
           }
         },
         "lit-html": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
-          "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+          "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
           "requires": {
             "@types/trusted-types": "^2.0.2"
           }
@@ -31064,9 +31156,9 @@
       "dev": true
     },
     "@types/trusted-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
-      "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
+      "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g=="
     },
     "@types/uglify-js": {
       "version": "3.13.3",
@@ -40353,28 +40445,29 @@
       }
     },
     "lit": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.4.1.tgz",
-      "integrity": "sha512-qohSgLiyN1cFnJG26dIiY03S4F49857A0AHQfnS0zYtnUVnD2MFvx+UT52rtXsIuNFQrnUupX+zyGSATlk1f/A==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "requires": {
-        "@lit/reactive-element": "^1.4.0",
-        "lit-element": "^3.2.0",
-        "lit-html": "^2.4.0"
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
       },
       "dependencies": {
         "lit-element": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-          "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+          "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
           "requires": {
+            "@lit-labs/ssr-dom-shim": "^1.1.0",
             "@lit/reactive-element": "^1.3.0",
-            "lit-html": "^2.2.0"
+            "lit-html": "^2.8.0"
           }
         },
         "lit-html": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.4.0.tgz",
-          "integrity": "sha512-G6qXu4JNUpY6aaF2VMfaszhO9hlWw0hOTRFDmuMheg/nDYGB+2RztUSOyrzALAbr8Nh0Y7qjhYkReh3rPnplVg==",
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+          "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
           "requires": {
             "@types/trusted-types": "^2.0.2"
           }
@@ -48114,9 +48207,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tslint": {
       "version": "5.20.1",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@mathigon/euclid": "^1.1.11",
     "@mathigon/studio": "0.1.18",
     "@qiskit-community/qiskit-vue": "^3.4.0",
-    "@qiskit/web-components": "^0.10.3",
+    "@qiskit/web-components": "^0.15.3",
     "@webcomponents/webcomponentsjs": "^2.6.0",
     "carbon-components": "~10.58.3",
     "carbon-web-components": "^1.21.0",


### PR DESCRIPTION
## Changes

Fixes #2190 

## Preview link
https://platypus-pr-2194.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/signin

## Implementation details
Upgrade to latest version of `@qiskit/web-components` to pull in the new navigation


## Screenshots


https://github.com/Qiskit/platypus/assets/6276074/a8a86c05-bcb1-496f-abdb-3ce15f4b54a9

