### PR TITLE
add redirects

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -14,7 +14,7 @@ import { LOCALES, translate } from '@mathigon/studio/server/utilities/i18n'
 import { generateMockData } from './populate-database'
 
 import {
-  CONFIG, NOTATIONS, TEXTBOOK_HOME, LATEST_TEXTBOOK_VERSION, TRANSLATIONS, UNIVERSAL_NOTATIONS,
+  CONFIG, NOTATIONS, TEXTBOOK_HOME, LATEST_TEXTBOOK_VERSION, TRANSLATIONS, UNIVERSAL_NOTATIONS, LEARNING_REDIRECTS,
   findNextSection, findPrevSection, getSectionIndex, isLearningPath,
   updateGlossary, loadLocaleRawFile, tocFilterByType, removeVersionPrefix
 } from './utilities'
@@ -138,7 +138,8 @@ const start = () => {
     .accounts()
     .redirects({
       '/': TEXTBOOK_HOME,
-      '/textbook': TEXTBOOK_HOME
+      '/textbook': TEXTBOOK_HOME,
+      ...LEARNING_REDIRECTS
     })
     .get('/locales/:locale', (req, res) => {
       const translations = TRANSLATIONS[req.params.locale || 'en'] || {}

--- a/server/utilities.ts
+++ b/server/utilities.ts
@@ -24,6 +24,16 @@ import {
 import { IS_PRODUCTION } from './configuration'
 
 const TEXTBOOK_HOME = 'https://qiskit.org/learn'
+const LEARNING_HOME = 'https://learning.quantum-computing.ibm.com'
+
+const LEARNING_REDIRECTS = {
+  '/course/algorithm-design': `${LEARNING_HOME}/course/variational-algorithm-design`,
+  '/course/algorithm-design/*': `${LEARNING_HOME}/course/variational-algorithm-design`,
+  '/course/basics': `${LEARNING_HOME}/course/basics-of-quantum-information`,
+  '/course/basics/*': `${LEARNING_HOME}/course/basics-of-quantum-information`,
+  '/course/algorithms': `${LEARNING_HOME}/course/fundamentals-of-quantum-algorithms`,
+  '/course/algorithms/*': `${LEARNING_HOME}/course/fundamentals-of-quantum-algorithms`
+}
 
 // NOTE: if changing this also update the same variable in 'converter/common.ts'
 const LATEST_TEXTBOOK_VERSION = 'v2'
@@ -182,6 +192,7 @@ export {
   TRANSLATIONS,
   UNIVERSAL_NOTATIONS,
   TOC,
+  LEARNING_REDIRECTS,
   findNextSection,
   findPrevSection,
   getSectionIndex,


### PR DESCRIPTION
## Changes

Fixes https://github.com/Qiskit/platypus/issues/2203

this PR adds redirects for the three courses that have migrated to the new learning platform

## Implementation details

the following redirects have been added:

- `/course/algorithm-design`  ➔  https://learning.quantum-computing.ibm.com/course/variational-algorithm-design
- `/course/basics`  ➔  https://learning.quantum-computing.ibm.com/course/basics-of-quantum-information
- `/course/algorithms`  ➔  https://learning.quantum-computing.ibm.com/course/fundamentals-of-quantum-algorithms


## How to read this PR

- review the redirection code updates
- test the redirections by attempting to access the course via the MegaMenuDropDown or preview link

## Preview URL

- https://platypus-pr-2204.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/basics
- https://platypus-pr-2204.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/algorithm-design
- https://platypus-pr-2204.ecy0akwlcpw.us-south.codeengine.appdomain.cloud/course/algorithms


